### PR TITLE
feat: Plan 애그리거트 구현

### DIFF
--- a/src/main/kotlin/com/flab/license/api/plan/PlanController.kt
+++ b/src/main/kotlin/com/flab/license/api/plan/PlanController.kt
@@ -1,0 +1,63 @@
+package com.flab.license.api.plan
+
+import com.flab.license.api.plan.dto.CreatePlanRequest
+import com.flab.license.api.plan.dto.PlanResponse
+import com.flab.license.api.plan.dto.UpdatePlanRequest
+import com.flab.license.common.response.ApiResponse
+import com.flab.license.domain.plan.PlanId
+import com.flab.license.service.plan.command.PlanCommandService
+import com.flab.license.service.plan.query.PlanQueryService
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+import java.util.UUID
+
+@RestController
+@RequestMapping("/plans")
+class PlanController(
+    private val planCommandService: PlanCommandService,
+    private val planQueryService: PlanQueryService
+) {
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    fun create(@Valid @RequestBody request: CreatePlanRequest): ApiResponse<PlanResponse> {
+        val plan = planCommandService.create(request.toCommand())
+        return ApiResponse.success(PlanResponse.from(plan))
+    }
+
+    @GetMapping
+    fun getAll(): ApiResponse<List<PlanResponse>> {
+        val plans = planQueryService.getAll()
+        return ApiResponse.success(plans.map { PlanResponse.from(it) })
+    }
+
+    @GetMapping("/{planId}")
+    fun getById(@PathVariable planId: UUID): ApiResponse<PlanResponse> {
+        val plan = planQueryService.getById(PlanId(planId))
+        return ApiResponse.success(PlanResponse.from(plan))
+    }
+
+    @PutMapping("/{planId}")
+    fun update(
+        @PathVariable planId: UUID,
+        @Valid @RequestBody request: UpdatePlanRequest
+    ): ApiResponse<PlanResponse> {
+        val plan = planCommandService.update(request.toCommand(PlanId(planId)))
+        return ApiResponse.success(PlanResponse.from(plan))
+    }
+
+    @DeleteMapping("/{planId}")
+    fun delete(@PathVariable planId: UUID): ApiResponse<Unit> {
+        planCommandService.delete(PlanId(planId))
+        return ApiResponse.ok()
+    }
+}

--- a/src/main/kotlin/com/flab/license/api/plan/dto/CreatePlanRequest.kt
+++ b/src/main/kotlin/com/flab/license/api/plan/dto/CreatePlanRequest.kt
@@ -1,0 +1,24 @@
+package com.flab.license.api.plan.dto
+
+import com.flab.license.common.validation.EnumValue
+import com.flab.license.domain.plan.PlanCode
+import com.flab.license.service.plan.command.CreatePlanCommand
+import jakarta.validation.constraints.Min
+
+data class CreatePlanRequest(
+    @field:EnumValue(enumClass = PlanCode::class, ignoreCase = true, message = "유효한 플랜 코드가 아닙니다")
+    val planCode: String,
+
+    @field:Min(value = 1, message = "최대 좌석 수는 1 이상이어야 합니다")
+    val maxSeats: Int,
+
+    @field:Min(value = 1, message = "월별 토큰 한도는 1 이상이어야 합니다")
+    val monthlyTokenLimit: Long
+) {
+    fun toCommand(): CreatePlanCommand =
+        CreatePlanCommand(
+            planCode = PlanCode.valueOf(planCode.uppercase()),
+            maxSeats = maxSeats,
+            monthlyTokenLimit = monthlyTokenLimit
+        )
+}

--- a/src/main/kotlin/com/flab/license/api/plan/dto/PlanResponse.kt
+++ b/src/main/kotlin/com/flab/license/api/plan/dto/PlanResponse.kt
@@ -1,0 +1,23 @@
+package com.flab.license.api.plan.dto
+
+import com.flab.license.domain.plan.Plan
+import com.flab.license.domain.plan.PlanCode
+import java.util.UUID
+
+data class PlanResponse(
+    val id: UUID,
+    val planCode: PlanCode,
+    val maxSeats: Int,
+    val monthlyTokenLimit: Long
+) {
+    companion object {
+        fun from(plan: Plan): PlanResponse {
+            return PlanResponse(
+                id = plan.id.value,
+                planCode = plan.planCode,
+                maxSeats = plan.maxSeats,
+                monthlyTokenLimit = plan.monthlyTokenLimit
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/flab/license/api/plan/dto/UpdatePlanRequest.kt
+++ b/src/main/kotlin/com/flab/license/api/plan/dto/UpdatePlanRequest.kt
@@ -1,0 +1,20 @@
+package com.flab.license.api.plan.dto
+
+import com.flab.license.domain.plan.PlanId
+import com.flab.license.service.plan.command.UpdatePlanCommand
+import jakarta.validation.constraints.Min
+
+data class UpdatePlanRequest(
+    @field:Min(value = 1, message = "최대 좌석 수는 1 이상이어야 합니다")
+    val maxSeats: Int,
+
+    @field:Min(value = 1, message = "월별 토큰 한도는 1 이상이어야 합니다")
+    val monthlyTokenLimit: Long
+) {
+    fun toCommand(planId: PlanId): UpdatePlanCommand =
+        UpdatePlanCommand(
+            planId = planId,
+            maxSeats = maxSeats,
+            monthlyTokenLimit = monthlyTokenLimit
+        )
+}

--- a/src/main/kotlin/com/flab/license/common/exception/CommonErrorCode.kt
+++ b/src/main/kotlin/com/flab/license/common/exception/CommonErrorCode.kt
@@ -13,5 +13,6 @@ enum class CommonErrorCode(
     TYPE_MISMATCH(HttpStatus.BAD_REQUEST, "요청 파라미터의 타입이 올바르지 않습니다"),
     RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "요청한 리소스를 찾을 수 없습니다"),
     METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "지원하지 않는 HTTP 메서드입니다"),
+    NOT_IMPLEMENTED(HttpStatus.NOT_IMPLEMENTED, "아직 구현되지 않은 기능입니다"),
     INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "내부 서버 오류가 발생했습니다")
 }

--- a/src/main/kotlin/com/flab/license/common/exception/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/com/flab/license/common/exception/GlobalExceptionHandler.kt
@@ -1,5 +1,6 @@
 package com.flab.license.common.exception
 
+import com.fasterxml.jackson.databind.exc.MismatchedInputException
 import com.flab.license.common.response.ApiResponse
 import mu.KotlinLogging
 import org.springframework.http.ResponseEntity
@@ -29,10 +30,10 @@ class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(MethodArgumentNotValidException::class)
-    fun handleMethodArgumentNotValidException(
-        e: MethodArgumentNotValidException
-    ): ResponseEntity<ApiResponse<Unit>> {
-        log.warn { "Validation failed: ${e.message}" }
+    fun handleMethodArgumentNotValidException(e: MethodArgumentNotValidException): ResponseEntity<ApiResponse<Unit>> {
+        val errors = e.bindingResult.fieldErrors
+            .joinToString(", ") { "${it.field}='${it.rejectedValue}' (${it.defaultMessage})" }
+        log.warn { "Validation failed: $errors" }
 
         return ResponseEntity
             .status(CommonErrorCode.INVALID_INPUT.httpStatus)
@@ -40,14 +41,23 @@ class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(HttpMessageNotReadableException::class)
-    fun handleHttpMessageNotReadableException(
-        e: HttpMessageNotReadableException
-    ): ResponseEntity<ApiResponse<Unit>> {
-        log.warn { "Message not readable: ${e.message}" }
+    fun handleHttpMessageNotReadableException(e: HttpMessageNotReadableException): ResponseEntity<ApiResponse<Unit>> {
+        return when (val cause = e.cause) {
+            is MismatchedInputException -> {
+                val field = cause.path.joinToString(".") { it.fieldName ?: "unknown" }
+                log.warn { "Missing required field: $field" }
+                ResponseEntity
+                    .status(CommonErrorCode.INVALID_INPUT.httpStatus)
+                    .body(ApiResponse.error(CommonErrorCode.INVALID_INPUT))
+            }
 
-        return ResponseEntity
-            .status(CommonErrorCode.INVALID_JSON.httpStatus)
-            .body(ApiResponse.error(CommonErrorCode.INVALID_JSON))
+            else -> {
+                log.warn { "Message not readable: ${e.message}" }
+                ResponseEntity
+                    .status(CommonErrorCode.INVALID_JSON.httpStatus)
+                    .body(ApiResponse.error(CommonErrorCode.INVALID_JSON))
+            }
+        }
     }
 
     @ExceptionHandler(MissingServletRequestParameterException::class)

--- a/src/main/kotlin/com/flab/license/common/validation/EnumValue.kt
+++ b/src/main/kotlin/com/flab/license/common/validation/EnumValue.kt
@@ -1,0 +1,37 @@
+package com.flab.license.common.validation
+
+import jakarta.validation.Constraint
+import jakarta.validation.ConstraintValidator
+import jakarta.validation.ConstraintValidatorContext
+import jakarta.validation.Payload
+import kotlin.reflect.KClass
+
+@Target(AnnotationTarget.FIELD)
+@Retention(AnnotationRetention.RUNTIME)
+@Constraint(validatedBy = [EnumValueValidator::class])
+annotation class EnumValue(
+    val message: String = "유효하지 않은 값입니다",
+    val groups: Array<KClass<*>> = [],
+    val payload: Array<KClass<out Payload>> = [],
+    val enumClass: KClass<out Enum<*>>,
+    val ignoreCase: Boolean = false
+)
+
+class EnumValueValidator : ConstraintValidator<EnumValue, String> {
+
+    private lateinit var enumValues: Array<out Enum<*>>
+    private var ignoreCase: Boolean = false
+
+    override fun initialize(constraintAnnotation: EnumValue) {
+        this.enumValues = constraintAnnotation.enumClass.java.enumConstants
+        this.ignoreCase = constraintAnnotation.ignoreCase
+    }
+
+    override fun isValid(value: String?, context: ConstraintValidatorContext): Boolean {
+        if (value.isNullOrBlank()) return true  // @NotBlank가 처리
+
+        return enumValues.any { enumValue ->
+            value.equals(enumValue.name, ignoreCase = this.ignoreCase)
+        }
+    }
+}

--- a/src/main/kotlin/com/flab/license/domain/plan/Plan.kt
+++ b/src/main/kotlin/com/flab/license/domain/plan/Plan.kt
@@ -59,14 +59,12 @@ class Plan private constructor(
             maxSeats: Int,
             monthlyTokenLimit: Long,
             deleted: Boolean
-        ): Plan {
-            return Plan(
-                id = id,
-                planCode = planCode,
-                maxSeats = maxSeats,
-                monthlyTokenLimit = monthlyTokenLimit,
-                deleted = deleted
-            )
-        }
+        ) = Plan(
+            id = id,
+            planCode = planCode,
+            maxSeats = maxSeats,
+            monthlyTokenLimit = monthlyTokenLimit,
+            deleted = deleted
+        )
     }
 }

--- a/src/main/kotlin/com/flab/license/domain/plan/Plan.kt
+++ b/src/main/kotlin/com/flab/license/domain/plan/Plan.kt
@@ -10,25 +10,18 @@ class Plan private constructor(
     val monthlyTokenLimit: Long,
     val deleted: Boolean = false
 ) {
-    init {
-        if (maxSeats < 0) {
-            throw PlanException(PlanErrorCode.INVALID_MAX_SEATS)
-        }
-        if (monthlyTokenLimit < 0) {
-            throw PlanException(PlanErrorCode.INVALID_MONTHLY_TOKEN_LIMIT)
-        }
-    }
 
     fun update(maxSeats: Int, monthlyTokenLimit: Long): Plan {
         if (deleted) {
             throw PlanException(PlanErrorCode.PLAN_ALREADY_DELETED)
         }
+        PlanPolicy.validate(planCode, maxSeats, monthlyTokenLimit)
         return Plan(
             id = this.id,
             planCode = this.planCode,
             maxSeats = maxSeats,
             monthlyTokenLimit = monthlyTokenLimit,
-            deleted = this.deleted
+            deleted = false
         )
     }
 
@@ -51,6 +44,7 @@ class Plan private constructor(
             maxSeats: Int,
             monthlyTokenLimit: Long
         ): Plan {
+            PlanPolicy.validate(planCode, maxSeats, monthlyTokenLimit)
             return Plan(
                 id = PlanId.generate(),
                 planCode = planCode,

--- a/src/main/kotlin/com/flab/license/domain/plan/Plan.kt
+++ b/src/main/kotlin/com/flab/license/domain/plan/Plan.kt
@@ -1,0 +1,78 @@
+package com.flab.license.domain.plan
+
+import com.flab.license.domain.plan.exception.PlanErrorCode
+import com.flab.license.domain.plan.exception.PlanException
+
+class Plan private constructor(
+    val id: PlanId,
+    val planCode: PlanCode,
+    val maxSeats: Int,
+    val monthlyTokenLimit: Long,
+    val deleted: Boolean = false
+) {
+    init {
+        if (maxSeats < 0) {
+            throw PlanException(PlanErrorCode.INVALID_MAX_SEATS)
+        }
+        if (monthlyTokenLimit < 0) {
+            throw PlanException(PlanErrorCode.INVALID_MONTHLY_TOKEN_LIMIT)
+        }
+    }
+
+    fun update(maxSeats: Int, monthlyTokenLimit: Long): Plan {
+        if (deleted) {
+            throw PlanException(PlanErrorCode.PLAN_ALREADY_DELETED)
+        }
+        return Plan(
+            id = this.id,
+            planCode = this.planCode,
+            maxSeats = maxSeats,
+            monthlyTokenLimit = monthlyTokenLimit,
+            deleted = this.deleted
+        )
+    }
+
+    fun delete(): Plan {
+        if (deleted) {
+            throw PlanException(PlanErrorCode.PLAN_ALREADY_DELETED)
+        }
+        return Plan(
+            id = this.id,
+            planCode = this.planCode,
+            maxSeats = this.maxSeats,
+            monthlyTokenLimit = this.monthlyTokenLimit,
+            deleted = true
+        )
+    }
+
+    companion object {
+        fun create(
+            planCode: PlanCode,
+            maxSeats: Int,
+            monthlyTokenLimit: Long
+        ): Plan {
+            return Plan(
+                id = PlanId.generate(),
+                planCode = planCode,
+                maxSeats = maxSeats,
+                monthlyTokenLimit = monthlyTokenLimit
+            )
+        }
+
+        fun reconstitute(
+            id: PlanId,
+            planCode: PlanCode,
+            maxSeats: Int,
+            monthlyTokenLimit: Long,
+            deleted: Boolean
+        ): Plan {
+            return Plan(
+                id = id,
+                planCode = planCode,
+                maxSeats = maxSeats,
+                monthlyTokenLimit = monthlyTokenLimit,
+                deleted = deleted
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/flab/license/domain/plan/PlanCode.kt
+++ b/src/main/kotlin/com/flab/license/domain/plan/PlanCode.kt
@@ -1,0 +1,7 @@
+package com.flab.license.domain.plan
+
+enum class PlanCode {
+    FREE,
+    PRO,
+    ENTERPRISE
+}

--- a/src/main/kotlin/com/flab/license/domain/plan/PlanId.kt
+++ b/src/main/kotlin/com/flab/license/domain/plan/PlanId.kt
@@ -1,0 +1,18 @@
+package com.flab.license.domain.plan
+
+import com.flab.license.domain.plan.exception.PlanErrorCode
+import com.flab.license.domain.plan.exception.PlanException
+import java.util.UUID
+
+@JvmInline
+value class PlanId(val value: UUID) {
+    companion object {
+        fun generate(): PlanId = PlanId(UUID.randomUUID())
+
+        fun from(value: String): PlanId = runCatching {
+            PlanId(UUID.fromString(value))
+        }.getOrElse {
+            throw PlanException(PlanErrorCode.INVALID_PLAN_ID)
+        }
+    }
+}

--- a/src/main/kotlin/com/flab/license/domain/plan/PlanPolicy.kt
+++ b/src/main/kotlin/com/flab/license/domain/plan/PlanPolicy.kt
@@ -1,0 +1,36 @@
+package com.flab.license.domain.plan
+
+import com.flab.license.domain.plan.exception.PlanErrorCode
+import com.flab.license.domain.plan.exception.PlanException
+
+object PlanPolicy {
+    private const val MIN_MAX_SEATS = 1
+    private const val MIN_MONTHLY_TOKEN_LIMIT = 1L
+    private const val SINGLE_SEAT_MAX_SEATS = 1
+
+    private val SINGLE_SEAT_PLANS = setOf(PlanCode.FREE, PlanCode.PRO)
+
+    fun validate(planCode: PlanCode, maxSeats: Int, monthlyTokenLimit: Long) {
+        validateMaxSeats(maxSeats)
+        validateMonthlyTokenLimit(monthlyTokenLimit)
+        validateMaxSeatsForPlan(planCode, maxSeats)
+    }
+
+    private fun validateMaxSeats(maxSeats: Int) {
+        if (maxSeats < MIN_MAX_SEATS) {
+            throw PlanException(PlanErrorCode.INVALID_MAX_SEATS)
+        }
+    }
+
+    private fun validateMonthlyTokenLimit(monthlyTokenLimit: Long) {
+        if (monthlyTokenLimit < MIN_MONTHLY_TOKEN_LIMIT) {
+            throw PlanException(PlanErrorCode.INVALID_MONTHLY_TOKEN_LIMIT)
+        }
+    }
+
+    private fun validateMaxSeatsForPlan(planCode: PlanCode, maxSeats: Int) {
+        if (planCode in SINGLE_SEAT_PLANS && maxSeats != SINGLE_SEAT_MAX_SEATS) {
+            throw PlanException(PlanErrorCode.INVALID_MAX_SEATS_FOR_PLAN)
+        }
+    }
+}

--- a/src/main/kotlin/com/flab/license/domain/plan/PlanRepository.kt
+++ b/src/main/kotlin/com/flab/license/domain/plan/PlanRepository.kt
@@ -1,0 +1,3 @@
+package com.flab.license.domain.plan
+
+interface PlanRepository

--- a/src/main/kotlin/com/flab/license/domain/plan/PlanRepository.kt
+++ b/src/main/kotlin/com/flab/license/domain/plan/PlanRepository.kt
@@ -1,3 +1,14 @@
 package com.flab.license.domain.plan
 
-interface PlanRepository
+interface PlanRepository {
+    fun save(plan: Plan): Plan
+    fun update(plan: Plan): Plan
+    fun delete(plan: Plan): Plan
+
+    fun loadById(id: PlanId): Plan
+    fun loadByPlanCode(planCode: PlanCode): Plan
+    fun loadAll(): List<Plan>
+
+    // 삭제된 플랜 포함 조회 (관리자용)
+    fun loadByIdIncludeDeleted(id: PlanId): Plan
+}

--- a/src/main/kotlin/com/flab/license/domain/plan/exception/PlanErrorCode.kt
+++ b/src/main/kotlin/com/flab/license/domain/plan/exception/PlanErrorCode.kt
@@ -1,0 +1,15 @@
+package com.flab.license.domain.plan.exception
+
+import com.flab.license.common.exception.ErrorCode
+import org.springframework.http.HttpStatus
+
+enum class PlanErrorCode(
+    override val httpStatus: HttpStatus,
+    override val message: String
+) : ErrorCode {
+
+    INVALID_PLAN_ID(HttpStatus.BAD_REQUEST, "유효하지 않은 플랜 ID입니다"),
+    INVALID_MAX_SEATS(HttpStatus.BAD_REQUEST, "최대 좌석 수는 0 이상이어야 합니다"),
+    INVALID_MONTHLY_TOKEN_LIMIT(HttpStatus.BAD_REQUEST, "월별 토큰 한도는 0 이상이어야 합니다"),
+    PLAN_ALREADY_DELETED(HttpStatus.BAD_REQUEST, "이미 삭제된 플랜입니다")
+}

--- a/src/main/kotlin/com/flab/license/domain/plan/exception/PlanErrorCode.kt
+++ b/src/main/kotlin/com/flab/license/domain/plan/exception/PlanErrorCode.kt
@@ -10,7 +10,8 @@ enum class PlanErrorCode(
 
     PLAN_NOT_FOUND(HttpStatus.NOT_FOUND, "플랜을 찾을 수 없습니다"),
     INVALID_PLAN_ID(HttpStatus.BAD_REQUEST, "유효하지 않은 플랜 ID입니다"),
-    INVALID_MAX_SEATS(HttpStatus.BAD_REQUEST, "최대 좌석 수는 0 이상이어야 합니다"),
-    INVALID_MONTHLY_TOKEN_LIMIT(HttpStatus.BAD_REQUEST, "월별 토큰 한도는 0 이상이어야 합니다"),
+    INVALID_MAX_SEATS(HttpStatus.BAD_REQUEST, "최대 좌석 수는 1 이상이어야 합니다"),
+    INVALID_MONTHLY_TOKEN_LIMIT(HttpStatus.BAD_REQUEST, "월별 토큰 한도는 1 이상이어야 합니다"),
+    INVALID_MAX_SEATS_FOR_PLAN(HttpStatus.BAD_REQUEST, "FREE/PRO 플랜은 최대 좌석 수가 1이어야 합니다"),
     PLAN_ALREADY_DELETED(HttpStatus.BAD_REQUEST, "이미 삭제된 플랜입니다")
 }

--- a/src/main/kotlin/com/flab/license/domain/plan/exception/PlanErrorCode.kt
+++ b/src/main/kotlin/com/flab/license/domain/plan/exception/PlanErrorCode.kt
@@ -8,6 +8,7 @@ enum class PlanErrorCode(
     override val message: String
 ) : ErrorCode {
 
+    PLAN_NOT_FOUND(HttpStatus.NOT_FOUND, "플랜을 찾을 수 없습니다"),
     INVALID_PLAN_ID(HttpStatus.BAD_REQUEST, "유효하지 않은 플랜 ID입니다"),
     INVALID_MAX_SEATS(HttpStatus.BAD_REQUEST, "최대 좌석 수는 0 이상이어야 합니다"),
     INVALID_MONTHLY_TOKEN_LIMIT(HttpStatus.BAD_REQUEST, "월별 토큰 한도는 0 이상이어야 합니다"),

--- a/src/main/kotlin/com/flab/license/domain/plan/exception/PlanException.kt
+++ b/src/main/kotlin/com/flab/license/domain/plan/exception/PlanException.kt
@@ -1,0 +1,5 @@
+package com.flab.license.domain.plan.exception
+
+import com.flab.license.common.exception.CustomException
+
+class PlanException(errorCode: PlanErrorCode) : CustomException(errorCode)

--- a/src/main/kotlin/com/flab/license/infra/persistence/plan/jpa/PlanJpaEntity.kt
+++ b/src/main/kotlin/com/flab/license/infra/persistence/plan/jpa/PlanJpaEntity.kt
@@ -1,8 +1,6 @@
 package com.flab.license.infra.persistence.plan.jpa
 
-import com.flab.license.domain.plan.Plan
 import com.flab.license.domain.plan.PlanCode
-import com.flab.license.domain.plan.PlanId
 import com.flab.license.infra.persistence.common.jpa.BaseTimeEntity
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
@@ -31,23 +29,4 @@ class PlanJpaEntity(
 
     @Column(nullable = false)
     val deleted: Boolean = false
-) : BaseTimeEntity() {
-
-    fun toDomain(): Plan = Plan.reconstitute(
-        id = PlanId(id),
-        planCode = planCode,
-        maxSeats = maxSeats,
-        monthlyTokenLimit = monthlyTokenLimit,
-        deleted = deleted
-    )
-
-    companion object {
-        fun fromDomain(plan: Plan): PlanJpaEntity = PlanJpaEntity(
-            id = plan.id.value,
-            planCode = plan.planCode,
-            maxSeats = plan.maxSeats,
-            monthlyTokenLimit = plan.monthlyTokenLimit,
-            deleted = plan.deleted
-        )
-    }
-}
+) : BaseTimeEntity()

--- a/src/main/kotlin/com/flab/license/infra/persistence/plan/jpa/PlanJpaEntity.kt
+++ b/src/main/kotlin/com/flab/license/infra/persistence/plan/jpa/PlanJpaEntity.kt
@@ -1,0 +1,53 @@
+package com.flab.license.infra.persistence.plan.jpa
+
+import com.flab.license.domain.plan.Plan
+import com.flab.license.domain.plan.PlanCode
+import com.flab.license.domain.plan.PlanId
+import com.flab.license.infra.persistence.common.jpa.BaseTimeEntity
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import java.util.UUID
+
+@Entity
+@Table(name = "plan")
+class PlanJpaEntity(
+    @Id
+    @Column(columnDefinition = "BINARY(16)")
+    val id: UUID,
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    val planCode: PlanCode,
+
+    @Column(nullable = false)
+    val maxSeats: Int,
+
+    @Column(nullable = false)
+    val monthlyTokenLimit: Long,
+
+    @Column(nullable = false)
+    val deleted: Boolean = false
+) : BaseTimeEntity() {
+
+    fun toDomain(): Plan = Plan.reconstitute(
+        id = PlanId(id),
+        planCode = planCode,
+        maxSeats = maxSeats,
+        monthlyTokenLimit = monthlyTokenLimit,
+        deleted = deleted
+    )
+
+    companion object {
+        fun fromDomain(plan: Plan): PlanJpaEntity = PlanJpaEntity(
+            id = plan.id.value,
+            planCode = plan.planCode,
+            maxSeats = plan.maxSeats,
+            monthlyTokenLimit = plan.monthlyTokenLimit,
+            deleted = plan.deleted
+        )
+    }
+}

--- a/src/main/kotlin/com/flab/license/infra/persistence/plan/jpa/PlanJpaMapper.kt
+++ b/src/main/kotlin/com/flab/license/infra/persistence/plan/jpa/PlanJpaMapper.kt
@@ -1,0 +1,20 @@
+package com.flab.license.infra.persistence.plan.jpa
+
+import com.flab.license.domain.plan.Plan
+import com.flab.license.domain.plan.PlanId
+
+internal fun PlanJpaEntity.toDomain(): Plan = Plan.reconstitute(
+    id = PlanId(id),
+    planCode = planCode,
+    maxSeats = maxSeats,
+    monthlyTokenLimit = monthlyTokenLimit,
+    deleted = deleted
+)
+
+internal fun Plan.toEntity(): PlanJpaEntity = PlanJpaEntity(
+    id = id.value,
+    planCode = planCode,
+    maxSeats = maxSeats,
+    monthlyTokenLimit = monthlyTokenLimit,
+    deleted = deleted
+)

--- a/src/main/kotlin/com/flab/license/infra/persistence/plan/jpa/PlanRepositoryJpaAdapter.kt
+++ b/src/main/kotlin/com/flab/license/infra/persistence/plan/jpa/PlanRepositoryJpaAdapter.kt
@@ -1,9 +1,51 @@
 package com.flab.license.infra.persistence.plan.jpa
 
+import com.flab.license.common.exception.CommonErrorCode
+import com.flab.license.common.exception.CustomException
+import com.flab.license.domain.plan.Plan
+import com.flab.license.domain.plan.PlanCode
+import com.flab.license.domain.plan.PlanId
 import com.flab.license.domain.plan.PlanRepository
+import com.flab.license.domain.plan.exception.PlanErrorCode
+import com.flab.license.domain.plan.exception.PlanException
 import org.springframework.stereotype.Repository
 
 @Repository
 class PlanRepositoryJpaAdapter(
     private val springDataJpaRepository: PlanSpringDataJpaRepository
-) : PlanRepository
+) : PlanRepository {
+
+    override fun save(plan: Plan): Plan {
+        val entity = PlanJpaEntity.fromDomain(plan)
+        val saved = springDataJpaRepository.save(entity)
+        return saved.toDomain()
+    }
+
+    override fun update(plan: Plan): Plan = save(plan)
+
+    override fun delete(plan: Plan): Plan = save(plan)
+
+    override fun loadById(id: PlanId): Plan {
+        return findById(id) ?: throw PlanException(PlanErrorCode.PLAN_NOT_FOUND)
+    }
+
+    override fun loadByPlanCode(planCode: PlanCode): Plan {
+        return findByPlanCode(planCode) ?: throw PlanException(PlanErrorCode.PLAN_NOT_FOUND)
+    }
+
+    override fun loadAll(): List<Plan> {
+        return springDataJpaRepository.findAllByDeletedFalse().map { it.toDomain() }
+    }
+
+    private fun findById(id: PlanId): Plan? {
+        return springDataJpaRepository.findByIdAndDeletedFalse(id.value)?.toDomain()
+    }
+
+    private fun findByPlanCode(planCode: PlanCode): Plan? {
+        return springDataJpaRepository.findByPlanCodeAndDeletedFalse(planCode)?.toDomain()
+    }
+
+    override fun loadByIdIncludeDeleted(id: PlanId): Plan {
+        throw CustomException(CommonErrorCode.NOT_IMPLEMENTED)
+    }
+}

--- a/src/main/kotlin/com/flab/license/infra/persistence/plan/jpa/PlanRepositoryJpaAdapter.kt
+++ b/src/main/kotlin/com/flab/license/infra/persistence/plan/jpa/PlanRepositoryJpaAdapter.kt
@@ -16,7 +16,7 @@ class PlanRepositoryJpaAdapter(
 ) : PlanRepository {
 
     override fun save(plan: Plan): Plan {
-        val entity = PlanJpaEntity.fromDomain(plan)
+        val entity = plan.toEntity()
         val saved = springDataJpaRepository.save(entity)
         return saved.toDomain()
     }

--- a/src/main/kotlin/com/flab/license/infra/persistence/plan/jpa/PlanRepositoryJpaAdapter.kt
+++ b/src/main/kotlin/com/flab/license/infra/persistence/plan/jpa/PlanRepositoryJpaAdapter.kt
@@ -1,0 +1,9 @@
+package com.flab.license.infra.persistence.plan.jpa
+
+import com.flab.license.domain.plan.PlanRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+class PlanRepositoryJpaAdapter(
+    private val springDataJpaRepository: PlanSpringDataJpaRepository
+) : PlanRepository

--- a/src/main/kotlin/com/flab/license/infra/persistence/plan/jpa/PlanSpringDataJpaRepository.kt
+++ b/src/main/kotlin/com/flab/license/infra/persistence/plan/jpa/PlanSpringDataJpaRepository.kt
@@ -1,0 +1,6 @@
+package com.flab.license.infra.persistence.plan.jpa
+
+import org.springframework.data.jpa.repository.JpaRepository
+import java.util.UUID
+
+interface PlanSpringDataJpaRepository : JpaRepository<PlanJpaEntity, UUID>

--- a/src/main/kotlin/com/flab/license/infra/persistence/plan/jpa/PlanSpringDataJpaRepository.kt
+++ b/src/main/kotlin/com/flab/license/infra/persistence/plan/jpa/PlanSpringDataJpaRepository.kt
@@ -1,6 +1,11 @@
 package com.flab.license.infra.persistence.plan.jpa
 
+import com.flab.license.domain.plan.PlanCode
 import org.springframework.data.jpa.repository.JpaRepository
 import java.util.UUID
 
-interface PlanSpringDataJpaRepository : JpaRepository<PlanJpaEntity, UUID>
+interface PlanSpringDataJpaRepository : JpaRepository<PlanJpaEntity, UUID> {
+    fun findByIdAndDeletedFalse(id: UUID): PlanJpaEntity?
+    fun findByPlanCodeAndDeletedFalse(planCode: PlanCode): PlanJpaEntity?
+    fun findAllByDeletedFalse(): List<PlanJpaEntity>
+}

--- a/src/main/kotlin/com/flab/license/service/plan/command/CreatePlanCommand.kt
+++ b/src/main/kotlin/com/flab/license/service/plan/command/CreatePlanCommand.kt
@@ -1,16 +1,9 @@
 package com.flab.license.service.plan.command
 
 import com.flab.license.domain.plan.PlanCode
-import com.flab.license.domain.plan.PlanId
 
 data class CreatePlanCommand(
     val planCode: PlanCode,
-    val maxSeats: Int,
-    val monthlyTokenLimit: Long
-)
-
-data class UpdatePlanCommand(
-    val planId: PlanId,
     val maxSeats: Int,
     val monthlyTokenLimit: Long
 )

--- a/src/main/kotlin/com/flab/license/service/plan/command/PlanCommandService.kt
+++ b/src/main/kotlin/com/flab/license/service/plan/command/PlanCommandService.kt
@@ -32,9 +32,9 @@ class PlanCommandService(
     }
 
     @Transactional
-    fun delete(planId: PlanId): Plan {
+    fun delete(planId: PlanId) {
         val plan = planRepository.loadById(planId)
         val deleted = plan.delete()
-        return planRepository.delete(deleted)
+        planRepository.delete(deleted)
     }
 }

--- a/src/main/kotlin/com/flab/license/service/plan/command/PlanCommandService.kt
+++ b/src/main/kotlin/com/flab/license/service/plan/command/PlanCommandService.kt
@@ -1,0 +1,40 @@
+package com.flab.license.service.plan.command
+
+import com.flab.license.domain.plan.Plan
+import com.flab.license.domain.plan.PlanId
+import com.flab.license.domain.plan.PlanRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class PlanCommandService(
+    private val planRepository: PlanRepository
+) {
+
+    @Transactional
+    fun create(command: CreatePlanCommand): Plan {
+        val plan = Plan.create(
+            planCode = command.planCode,
+            maxSeats = command.maxSeats,
+            monthlyTokenLimit = command.monthlyTokenLimit
+        )
+        return planRepository.save(plan)
+    }
+
+    @Transactional
+    fun update(command: UpdatePlanCommand): Plan {
+        val plan = planRepository.loadById(command.planId)
+        val updated = plan.update(
+            maxSeats = command.maxSeats,
+            monthlyTokenLimit = command.monthlyTokenLimit
+        )
+        return planRepository.update(updated)
+    }
+
+    @Transactional
+    fun delete(planId: PlanId): Plan {
+        val plan = planRepository.loadById(planId)
+        val deleted = plan.delete()
+        return planRepository.delete(deleted)
+    }
+}

--- a/src/main/kotlin/com/flab/license/service/plan/command/PlanCommands.kt
+++ b/src/main/kotlin/com/flab/license/service/plan/command/PlanCommands.kt
@@ -1,0 +1,16 @@
+package com.flab.license.service.plan.command
+
+import com.flab.license.domain.plan.PlanCode
+import com.flab.license.domain.plan.PlanId
+
+data class CreatePlanCommand(
+    val planCode: PlanCode,
+    val maxSeats: Int,
+    val monthlyTokenLimit: Long
+)
+
+data class UpdatePlanCommand(
+    val planId: PlanId,
+    val maxSeats: Int,
+    val monthlyTokenLimit: Long
+)

--- a/src/main/kotlin/com/flab/license/service/plan/command/UpdatePlanCommand.kt
+++ b/src/main/kotlin/com/flab/license/service/plan/command/UpdatePlanCommand.kt
@@ -1,0 +1,9 @@
+package com.flab.license.service.plan.command
+
+import com.flab.license.domain.plan.PlanId
+
+data class UpdatePlanCommand(
+    val planId: PlanId,
+    val maxSeats: Int,
+    val monthlyTokenLimit: Long
+)

--- a/src/main/kotlin/com/flab/license/service/plan/query/PlanQueryService.kt
+++ b/src/main/kotlin/com/flab/license/service/plan/query/PlanQueryService.kt
@@ -1,0 +1,27 @@
+package com.flab.license.service.plan.query
+
+import com.flab.license.domain.plan.Plan
+import com.flab.license.domain.plan.PlanCode
+import com.flab.license.domain.plan.PlanId
+import com.flab.license.domain.plan.PlanRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional(readOnly = true)
+class PlanQueryService(
+    private val planRepository: PlanRepository
+) {
+
+    fun getById(planId: PlanId): Plan {
+        return planRepository.loadById(planId)
+    }
+
+    fun getByPlanCode(planCode: PlanCode): Plan {
+        return planRepository.loadByPlanCode(planCode)
+    }
+
+    fun getAll(): List<Plan> {
+        return planRepository.loadAll()
+    }
+}

--- a/src/test/kotlin/com/flab/license/api/plan/PlanControllerTest.kt
+++ b/src/test/kotlin/com/flab/license/api/plan/PlanControllerTest.kt
@@ -51,7 +51,7 @@ class PlanControllerTest {
         @DisplayName("플랜 생성 성공")
         fun `create plan successfully`() {
             val request = CreatePlanRequest(
-                planCode = "PRO",
+                planCode = "ENTERPRISE",
                 maxSeats = 10,
                 monthlyTokenLimit = 500_000L
             )
@@ -62,7 +62,7 @@ class PlanControllerTest {
             }.andExpect {
                 status { isCreated() }
                 jsonPath("$.success") { value(true) }
-                jsonPath("$.data.planCode") { value("PRO") }
+                jsonPath("$.data.planCode") { value("ENTERPRISE") }
                 jsonPath("$.data.maxSeats") { value(10) }
                 jsonPath("$.data.monthlyTokenLimit") { value(500_000) }
             }
@@ -168,7 +168,7 @@ class PlanControllerTest {
         fun `get all plans successfully`() {
             // Given
             val plan1 = Plan.create(PlanCode.FREE, 1, 50_000L)
-            val plan2 = Plan.create(PlanCode.PRO, 10, 500_000L)
+            val plan2 = Plan.create(PlanCode.ENTERPRISE, 10, 500_000L)
             planRepository.save(plan1)
             planRepository.save(plan2)
 
@@ -197,7 +197,7 @@ class PlanControllerTest {
         fun `exclude deleted plans from list`() {
             // Given
             val plan1 = Plan.create(PlanCode.FREE, 1, 50_000L)
-            val plan2 = Plan.create(PlanCode.PRO, 10, 500_000L)
+            val plan2 = Plan.create(PlanCode.ENTERPRISE, 10, 500_000L)
             planRepository.save(plan1)
             planRepository.save(plan2)
 
@@ -223,7 +223,7 @@ class PlanControllerTest {
         @DisplayName("플랜 상세 조회 성공")
         fun `get plan by id successfully`() {
             // Given
-            val plan = Plan.create(PlanCode.PRO, 10, 500_000L)
+            val plan = Plan.create(PlanCode.ENTERPRISE, 10, 500_000L)
             planRepository.save(plan)
 
             // When & Then
@@ -231,7 +231,7 @@ class PlanControllerTest {
                 .andExpect {
                     status { isOk() }
                     jsonPath("$.success") { value(true) }
-                    jsonPath("$.data.planCode") { value("PRO") }
+                    jsonPath("$.data.planCode") { value("ENTERPRISE") }
                     jsonPath("$.data.maxSeats") { value(10) }
                 }
         }
@@ -269,7 +269,7 @@ class PlanControllerTest {
         @DisplayName("플랜 수정 성공")
         fun `update plan successfully`() {
             // Given
-            val plan = Plan.create(PlanCode.PRO, 10, 500_000L)
+            val plan = Plan.create(PlanCode.ENTERPRISE, 10, 500_000L)
             planRepository.save(plan)
 
             val request = UpdatePlanRequest(
@@ -293,7 +293,7 @@ class PlanControllerTest {
         @DisplayName("최소값(maxSeats=1, monthlyTokenLimit=1)으로 플랜 수정 성공")
         fun `update plan with minimum values`() {
             // Given
-            val plan = Plan.create(PlanCode.PRO, 10, 500_000L)
+            val plan = Plan.create(PlanCode.ENTERPRISE, 10, 500_000L)
             planRepository.save(plan)
 
             val request = UpdatePlanRequest(
@@ -356,7 +356,7 @@ class PlanControllerTest {
         @DisplayName("플랜 삭제 성공")
         fun `delete plan successfully`() {
             // Given
-            val plan = Plan.create(PlanCode.PRO, 10, 500_000L)
+            val plan = Plan.create(PlanCode.ENTERPRISE, 10, 500_000L)
             planRepository.save(plan)
 
             // When & Then

--- a/src/test/kotlin/com/flab/license/api/plan/PlanControllerTest.kt
+++ b/src/test/kotlin/com/flab/license/api/plan/PlanControllerTest.kt
@@ -1,0 +1,398 @@
+package com.flab.license.api.plan
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.flab.license.api.plan.dto.CreatePlanRequest
+import com.flab.license.api.plan.dto.UpdatePlanRequest
+import com.flab.license.domain.plan.Plan
+import com.flab.license.domain.plan.PlanCode
+import com.flab.license.domain.plan.PlanRepository
+import com.flab.license.infra.persistence.plan.jpa.PlanSpringDataJpaRepository
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.delete
+import org.springframework.test.web.servlet.get
+import org.springframework.test.web.servlet.post
+import org.springframework.test.web.servlet.put
+import java.util.UUID
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class PlanControllerTest {
+
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @Autowired
+    private lateinit var objectMapper: ObjectMapper
+
+    @Autowired
+    private lateinit var planRepository: PlanRepository
+
+    @Autowired
+    private lateinit var springDataJpaRepository: PlanSpringDataJpaRepository
+
+    @BeforeEach
+    fun setUp() {
+        springDataJpaRepository.deleteAll()
+    }
+
+    @Nested
+    @DisplayName("POST /plans")
+    inner class CreatePlan {
+
+        @Test
+        @DisplayName("플랜 생성 성공")
+        fun `create plan successfully`() {
+            val request = CreatePlanRequest(
+                planCode = "PRO",
+                maxSeats = 10,
+                monthlyTokenLimit = 500_000L
+            )
+
+            mockMvc.post("/plans") {
+                contentType = MediaType.APPLICATION_JSON
+                content = objectMapper.writeValueAsString(request)
+            }.andExpect {
+                status { isCreated() }
+                jsonPath("$.success") { value(true) }
+                jsonPath("$.data.planCode") { value("PRO") }
+                jsonPath("$.data.maxSeats") { value(10) }
+                jsonPath("$.data.monthlyTokenLimit") { value(500_000) }
+            }
+        }
+
+        @Test
+        @DisplayName("최소값(maxSeats=1, monthlyTokenLimit=1)으로 플랜 생성 성공")
+        fun `create plan with minimum values`() {
+            val request = CreatePlanRequest(
+                planCode = "FREE",
+                maxSeats = 1,
+                monthlyTokenLimit = 1L
+            )
+
+            mockMvc.post("/plans") {
+                contentType = MediaType.APPLICATION_JSON
+                content = objectMapper.writeValueAsString(request)
+            }.andExpect {
+                status { isCreated() }
+                jsonPath("$.success") { value(true) }
+                jsonPath("$.data.maxSeats") { value(1) }
+                jsonPath("$.data.monthlyTokenLimit") { value(1) }
+            }
+        }
+
+        @Test
+        @DisplayName("필수 필드(planCode) 누락 시 400 에러와 INVALID_INPUT 반환")
+        fun `return 400 when required field is missing`() {
+            val request = mapOf(
+                // planCode 누락
+                "maxSeats" to 10,
+                "monthlyTokenLimit" to 500_000
+            )
+
+            mockMvc.post("/plans") {
+                contentType = MediaType.APPLICATION_JSON
+                content = objectMapper.writeValueAsString(request)
+            }.andExpect {
+                status { isBadRequest() }
+                jsonPath("$.success") { value(false) }
+                jsonPath("$.error") { value("INVALID_INPUT") }
+            }
+        }
+
+        @Test
+        @DisplayName("유효하지 않은 값 전달 시 400 에러와 INVALID_INPUT 반환")
+        fun `return 400 when invalid value`() {
+            val request = mapOf(
+                "planCode" to "PRO",
+                "maxSeats" to -1,
+                "monthlyTokenLimit" to 500_000
+            )
+
+            mockMvc.post("/plans") {
+                contentType = MediaType.APPLICATION_JSON
+                content = objectMapper.writeValueAsString(request)
+            }.andExpect {
+                status { isBadRequest() }
+                jsonPath("$.error") { value("INVALID_INPUT") }
+                jsonPath("$.success") { value(false) }
+            }
+        }
+
+        @Test
+        @DisplayName("잘못된 JSON 형식 요청 시 400 에러와 INVALID_JSON 반환")
+        fun `return 400 when invalid json format`() {
+            mockMvc.post("/plans") {
+                contentType = MediaType.APPLICATION_JSON
+                content = "{ invalid json }"
+            }.andExpect {
+                status { isBadRequest() }
+                jsonPath("$.success") { value(false) }
+                jsonPath("$.error") { value("INVALID_JSON") }
+            }
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 PlanCode 값 전달 시 400 에러와 INVALID_INPUT 반환")
+        fun `return 400 when invalid enum value`() {
+            val request = mapOf(
+                "planCode" to "INVALID_PLAN_CODE",
+                "maxSeats" to 10,
+                "monthlyTokenLimit" to 500_000
+            )
+
+            mockMvc.post("/plans") {
+                contentType = MediaType.APPLICATION_JSON
+                content = objectMapper.writeValueAsString(request)
+            }.andExpect {
+                status { isBadRequest() }
+                jsonPath("$.success") { value(false) }
+                jsonPath("$.error") { value("INVALID_INPUT") }
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /plans")
+    inner class GetAllPlans {
+
+        @Test
+        @DisplayName("전체 플랜 목록 조회 성공")
+        fun `get all plans successfully`() {
+            // Given
+            val plan1 = Plan.create(PlanCode.FREE, 1, 50_000L)
+            val plan2 = Plan.create(PlanCode.PRO, 10, 500_000L)
+            planRepository.save(plan1)
+            planRepository.save(plan2)
+
+            // When & Then
+            mockMvc.get("/plans")
+                .andExpect {
+                    status { isOk() }
+                    jsonPath("$.success") { value(true) }
+                    jsonPath("$.data.length()") { value(2) }
+                }
+        }
+
+        @Test
+        @DisplayName("플랜이 없으면 빈 목록 반환")
+        fun `return empty list when no plans`() {
+            mockMvc.get("/plans")
+                .andExpect {
+                    status { isOk() }
+                    jsonPath("$.success") { value(true) }
+                    jsonPath("$.data.length()") { value(0) }
+                }
+        }
+
+        @Test
+        @DisplayName("삭제된 플랜은 목록에서 제외된다")
+        fun `exclude deleted plans from list`() {
+            // Given
+            val plan1 = Plan.create(PlanCode.FREE, 1, 50_000L)
+            val plan2 = Plan.create(PlanCode.PRO, 10, 500_000L)
+            planRepository.save(plan1)
+            planRepository.save(plan2)
+
+            // When - plan2 삭제
+            mockMvc.delete("/plans/${plan2.id.value}")
+                .andExpect { status { isOk() } }
+
+            // Then - 목록에서 plan2 제외 확인
+            mockMvc.get("/plans")
+                .andExpect {
+                    status { isOk() }
+                    jsonPath("$.data.length()") { value(1) }
+                    jsonPath("$.data[0].planCode") { value("FREE") }
+                }
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /plans/{planId}")
+    inner class GetPlanById {
+
+        @Test
+        @DisplayName("플랜 상세 조회 성공")
+        fun `get plan by id successfully`() {
+            // Given
+            val plan = Plan.create(PlanCode.PRO, 10, 500_000L)
+            planRepository.save(plan)
+
+            // When & Then
+            mockMvc.get("/plans/${plan.id.value}")
+                .andExpect {
+                    status { isOk() }
+                    jsonPath("$.success") { value(true) }
+                    jsonPath("$.data.planCode") { value("PRO") }
+                    jsonPath("$.data.maxSeats") { value(10) }
+                }
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 플랜 조회 시 404 에러")
+        fun `return 404 when plan not found`() {
+            val nonExistentId = UUID.randomUUID()
+
+            mockMvc.get("/plans/$nonExistentId")
+                .andExpect {
+                    status { isNotFound() }
+                    jsonPath("$.success") { value(false) }
+                    jsonPath("$.error") { value("PLAN_NOT_FOUND") }
+                }
+        }
+
+        @Test
+        @DisplayName("잘못된 UUID 형식 요청 시 400 에러")
+        fun `return 400 when invalid uuid format`() {
+            mockMvc.get("/plans/invalid-uuid")
+                .andExpect {
+                    status { isBadRequest() }
+                    jsonPath("$.success") { value(false) }
+                    jsonPath("$.error") { value("TYPE_MISMATCH") }
+                }
+        }
+    }
+
+    @Nested
+    @DisplayName("PUT /plans/{planId}")
+    inner class UpdatePlan {
+
+        @Test
+        @DisplayName("플랜 수정 성공")
+        fun `update plan successfully`() {
+            // Given
+            val plan = Plan.create(PlanCode.PRO, 10, 500_000L)
+            planRepository.save(plan)
+
+            val request = UpdatePlanRequest(
+                maxSeats = 20,
+                monthlyTokenLimit = 1_000_000L
+            )
+
+            // When & Then
+            mockMvc.put("/plans/${plan.id.value}") {
+                contentType = MediaType.APPLICATION_JSON
+                content = objectMapper.writeValueAsString(request)
+            }.andExpect {
+                status { isOk() }
+                jsonPath("$.success") { value(true) }
+                jsonPath("$.data.maxSeats") { value(20) }
+                jsonPath("$.data.monthlyTokenLimit") { value(1_000_000) }
+            }
+        }
+
+        @Test
+        @DisplayName("최소값(maxSeats=1, monthlyTokenLimit=1)으로 플랜 수정 성공")
+        fun `update plan with minimum values`() {
+            // Given
+            val plan = Plan.create(PlanCode.PRO, 10, 500_000L)
+            planRepository.save(plan)
+
+            val request = UpdatePlanRequest(
+                maxSeats = 1,
+                monthlyTokenLimit = 1L
+            )
+
+            // When & Then
+            mockMvc.put("/plans/${plan.id.value}") {
+                contentType = MediaType.APPLICATION_JSON
+                content = objectMapper.writeValueAsString(request)
+            }.andExpect {
+                status { isOk() }
+                jsonPath("$.data.maxSeats") { value(1) }
+                jsonPath("$.data.monthlyTokenLimit") { value(1) }
+            }
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 플랜 수정 시 404 에러")
+        fun `return 404 when plan not found`() {
+            val nonExistentId = UUID.randomUUID()
+            val request = UpdatePlanRequest(
+                maxSeats = 20,
+                monthlyTokenLimit = 1_000_000L
+            )
+
+            mockMvc.put("/plans/$nonExistentId") {
+                contentType = MediaType.APPLICATION_JSON
+                content = objectMapper.writeValueAsString(request)
+            }.andExpect {
+                status { isNotFound() }
+                jsonPath("$.success") { value(false) }
+            }
+        }
+
+        @Test
+        @DisplayName("잘못된 UUID 형식 요청 시 400 에러")
+        fun `return 400 when invalid uuid format`() {
+            val request = UpdatePlanRequest(
+                maxSeats = 20,
+                monthlyTokenLimit = 1_000_000L
+            )
+
+            mockMvc.put("/plans/invalid-uuid") {
+                contentType = MediaType.APPLICATION_JSON
+                content = objectMapper.writeValueAsString(request)
+            }.andExpect {
+                status { isBadRequest() }
+                jsonPath("$.error") { value("TYPE_MISMATCH") }
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("DELETE /plans/{planId}")
+    inner class DeletePlan {
+
+        @Test
+        @DisplayName("플랜 삭제 성공")
+        fun `delete plan successfully`() {
+            // Given
+            val plan = Plan.create(PlanCode.PRO, 10, 500_000L)
+            planRepository.save(plan)
+
+            // When & Then
+            mockMvc.delete("/plans/${plan.id.value}")
+                .andExpect {
+                    status { isOk() }
+                    jsonPath("$.success") { value(true) }
+                }
+
+            // Verify soft delete
+            mockMvc.get("/plans/${plan.id.value}")
+                .andExpect {
+                    status { isNotFound() }
+                }
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 플랜 삭제 시 404 에러")
+        fun `return 404 when plan not found`() {
+            val nonExistentId = UUID.randomUUID()
+
+            mockMvc.delete("/plans/$nonExistentId")
+                .andExpect {
+                    status { isNotFound() }
+                    jsonPath("$.success") { value(false) }
+                }
+        }
+
+        @Test
+        @DisplayName("잘못된 UUID 형식 요청 시 400 에러")
+        fun `return 400 when invalid uuid format`() {
+            mockMvc.delete("/plans/invalid-uuid")
+                .andExpect {
+                    status { isBadRequest() }
+                    jsonPath("$.error") { value("TYPE_MISMATCH") }
+                }
+        }
+    }
+}

--- a/src/test/kotlin/com/flab/license/common/exception/GlobalExceptionHandlerTest.kt
+++ b/src/test/kotlin/com/flab/license/common/exception/GlobalExceptionHandlerTest.kt
@@ -60,7 +60,12 @@ class GlobalExceptionHandlerTest {
     @DisplayName("MethodArgumentNotValidException 발생 시 400 상태코드와 INVALID_INPUT을 반환한다")
     fun `handleMethodArgumentNotValidException returns 400 with invalid input`() {
         // Given
-        val exception = mock<MethodArgumentNotValidException>()
+        val bindingResult = mock<org.springframework.validation.BindingResult> {
+            on { fieldErrors }.thenReturn(emptyList())
+        }
+        val exception = mock<MethodArgumentNotValidException> {
+            on { this.bindingResult }.thenReturn(bindingResult)
+        }
 
         // When
         val response = handler.handleMethodArgumentNotValidException(exception)

--- a/src/test/kotlin/com/flab/license/domain/plan/PlanIdTest.kt
+++ b/src/test/kotlin/com/flab/license/domain/plan/PlanIdTest.kt
@@ -1,0 +1,127 @@
+package com.flab.license.domain.plan
+
+import com.flab.license.domain.plan.exception.PlanErrorCode
+import com.flab.license.domain.plan.exception.PlanException
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.util.*
+
+class PlanIdTest {
+
+    @Nested
+    @DisplayName("generate")
+    inner class Generate {
+
+        @Test
+        @DisplayName("UUID를 생성할 수 있다")
+        fun `generate creates valid UUID`() {
+            // When
+            val planId = PlanId.generate()
+
+            // Then
+            assertThat(planId.value).isNotNull()
+            assertThat(planId.value).isInstanceOf(UUID::class.java)
+        }
+
+        @Test
+        @DisplayName("생성할 때마다 다른 UUID가 생성된다")
+        fun `generate creates unique UUIDs`() {
+            // When
+            val planId1 = PlanId.generate()
+            val planId2 = PlanId.generate()
+
+            // Then
+            assertThat(planId1).isNotEqualTo(planId2)
+        }
+    }
+
+    @Nested
+    @DisplayName("from")
+    inner class From {
+
+        @Test
+        @DisplayName("유효한 UUID 문자열로 PlanId를 생성할 수 있다")
+        fun `from creates PlanId from valid UUID string`() {
+            // Given
+            val uuidString = "550e8400-e29b-41d4-a716-446655440000"
+
+            // When
+            val planId = PlanId.from(uuidString)
+
+            // Then
+            assertThat(planId.value.toString()).isEqualTo(uuidString)
+        }
+
+        @Test
+        @DisplayName("잘못된 UUID 문자열이면 예외가 발생한다")
+        fun `from throws exception for invalid UUID string`() {
+            // Given
+            val invalidUuidString = "invalid-uuid"
+
+            // When & Then
+            assertThatThrownBy {
+                PlanId.from(invalidUuidString)
+            }.isInstanceOf(PlanException::class.java)
+                .extracting("errorCode")
+                .isEqualTo(PlanErrorCode.INVALID_PLAN_ID)
+        }
+
+        @Test
+        @DisplayName("빈 문자열이면 예외가 발생한다")
+        fun `from throws exception for empty string`() {
+            // When & Then
+            assertThatThrownBy {
+                PlanId.from("")
+            }.isInstanceOf(PlanException::class.java)
+                .extracting("errorCode")
+                .isEqualTo(PlanErrorCode.INVALID_PLAN_ID)
+        }
+
+        @Test
+        @DisplayName("UUID 형식이 아닌 문자열이면 예외가 발생한다")
+        fun `from throws exception for non-UUID format`() {
+            // Given
+            val nonUuidString = "12345"
+
+            // When & Then
+            assertThatThrownBy {
+                PlanId.from(nonUuidString)
+            }.isInstanceOf(PlanException::class.java)
+                .extracting("errorCode")
+                .isEqualTo(PlanErrorCode.INVALID_PLAN_ID)
+        }
+    }
+
+    @Nested
+    @DisplayName("equality")
+    inner class Equality {
+
+        @Test
+        @DisplayName("같은 UUID를 가진 PlanId는 동등하다")
+        fun `PlanIds with same UUID are equal`() {
+            // Given
+            val uuid = UUID.randomUUID()
+
+            // When
+            val planId1 = PlanId(uuid)
+            val planId2 = PlanId(uuid)
+
+            // Then
+            assertThat(planId1).isEqualTo(planId2)
+        }
+
+        @Test
+        @DisplayName("다른 UUID를 가진 PlanId는 동등하지 않다")
+        fun `PlanIds with different UUIDs are not equal`() {
+            // When
+            val planId1 = PlanId(UUID.randomUUID())
+            val planId2 = PlanId(UUID.randomUUID())
+
+            // Then
+            assertThat(planId1).isNotEqualTo(planId2)
+        }
+    }
+}

--- a/src/test/kotlin/com/flab/license/domain/plan/PlanPolicyTest.kt
+++ b/src/test/kotlin/com/flab/license/domain/plan/PlanPolicyTest.kt
@@ -1,0 +1,67 @@
+package com.flab.license.domain.plan
+
+import com.flab.license.domain.plan.exception.PlanErrorCode
+import com.flab.license.domain.plan.exception.PlanException
+import org.assertj.core.api.Assertions.assertThatCode
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
+
+class PlanPolicyTest {
+
+    @Nested
+    @DisplayName("validate")
+    inner class Validate {
+
+        @Test
+        @DisplayName("ENTERPRISE 플랜은 maxSeats가 1 이상이면 통과")
+        fun `enterprise plan with valid maxSeats passes`() {
+            assertThatCode {
+                PlanPolicy.validate(PlanCode.ENTERPRISE, 10, 100_000L)
+            }.doesNotThrowAnyException()
+        }
+
+        @ParameterizedTest
+        @EnumSource(value = PlanCode::class, names = ["FREE", "PRO"])
+        @DisplayName("FREE/PRO 플랜은 maxSeats가 1이면 통과")
+        fun `free and pro plan with maxSeats 1 passes`(planCode: PlanCode) {
+            assertThatCode {
+                PlanPolicy.validate(planCode, 1, 100_000L)
+            }.doesNotThrowAnyException()
+        }
+
+        @Test
+        @DisplayName("maxSeats가 0이면 INVALID_MAX_SEATS 예외")
+        fun `throw exception when maxSeats is zero`() {
+            assertThatThrownBy {
+                PlanPolicy.validate(PlanCode.ENTERPRISE, 0, 100_000L)
+            }.isInstanceOf(PlanException::class.java)
+                .extracting("errorCode")
+                .isEqualTo(PlanErrorCode.INVALID_MAX_SEATS)
+        }
+
+        @Test
+        @DisplayName("monthlyTokenLimit이 0이면 INVALID_MONTHLY_TOKEN_LIMIT 예외")
+        fun `throw exception when monthlyTokenLimit is zero`() {
+            assertThatThrownBy {
+                PlanPolicy.validate(PlanCode.ENTERPRISE, 10, 0L)
+            }.isInstanceOf(PlanException::class.java)
+                .extracting("errorCode")
+                .isEqualTo(PlanErrorCode.INVALID_MONTHLY_TOKEN_LIMIT)
+        }
+
+        @ParameterizedTest
+        @EnumSource(value = PlanCode::class, names = ["FREE", "PRO"])
+        @DisplayName("FREE/PRO 플랜에서 maxSeats가 1이 아니면 INVALID_MAX_SEATS_FOR_PLAN 예외")
+        fun `throw exception when free or pro plan has maxSeats not 1`(planCode: PlanCode) {
+            assertThatThrownBy {
+                PlanPolicy.validate(planCode, 5, 100_000L)
+            }.isInstanceOf(PlanException::class.java)
+                .extracting("errorCode")
+                .isEqualTo(PlanErrorCode.INVALID_MAX_SEATS_FOR_PLAN)
+        }
+    }
+}

--- a/src/test/kotlin/com/flab/license/domain/plan/PlanTest.kt
+++ b/src/test/kotlin/com/flab/license/domain/plan/PlanTest.kt
@@ -15,30 +15,60 @@ class PlanTest {
     inner class Create {
 
         @Test
-        @DisplayName("플랜을 생성할 수 있다")
-        fun `create plan successfully`() {
+        @DisplayName("ENTERPRISE 플랜을 생성할 수 있다")
+        fun `create enterprise plan successfully`() {
             // When
             val plan = Plan.create(
-                planCode = PlanCode.PRO,
+                planCode = PlanCode.ENTERPRISE,
                 maxSeats = 10,
                 monthlyTokenLimit = 100_000L
             )
 
             // Then
             assertThat(plan.id).isNotNull
-            assertThat(plan.planCode).isEqualTo(PlanCode.PRO)
+            assertThat(plan.planCode).isEqualTo(PlanCode.ENTERPRISE)
             assertThat(plan.maxSeats).isEqualTo(10)
             assertThat(plan.monthlyTokenLimit).isEqualTo(100_000L)
             assertThat(plan.deleted).isFalse
         }
 
         @Test
-        @DisplayName("maxSeats가 음수이면 예외가 발생한다")
-        fun `throw exception when maxSeats is negative`() {
+        @DisplayName("FREE 플랜은 maxSeats=1로 생성할 수 있다")
+        fun `create free plan with maxSeats 1`() {
+            // When
+            val plan = Plan.create(
+                planCode = PlanCode.FREE,
+                maxSeats = 1,
+                monthlyTokenLimit = 10_000L
+            )
+
+            // Then
+            assertThat(plan.planCode).isEqualTo(PlanCode.FREE)
+            assertThat(plan.maxSeats).isEqualTo(1)
+        }
+
+        @Test
+        @DisplayName("PRO 플랜은 maxSeats=1로 생성할 수 있다")
+        fun `create pro plan with maxSeats 1`() {
+            // When
+            val plan = Plan.create(
+                planCode = PlanCode.PRO,
+                maxSeats = 1,
+                monthlyTokenLimit = 100_000L
+            )
+
+            // Then
+            assertThat(plan.planCode).isEqualTo(PlanCode.PRO)
+            assertThat(plan.maxSeats).isEqualTo(1)
+        }
+
+        @Test
+        @DisplayName("maxSeats가 0이면 예외가 발생한다")
+        fun `throw exception when maxSeats is zero`() {
             assertThatThrownBy {
                 Plan.create(
-                    planCode = PlanCode.PRO,
-                    maxSeats = -1,
+                    planCode = PlanCode.ENTERPRISE,
+                    maxSeats = 0,
                     monthlyTokenLimit = 100_000L
                 )
             }.isInstanceOf(PlanException::class.java)
@@ -47,13 +77,13 @@ class PlanTest {
         }
 
         @Test
-        @DisplayName("monthlyTokenLimit이 음수이면 예외가 발생한다")
-        fun `throw exception when monthlyTokenLimit is negative`() {
+        @DisplayName("monthlyTokenLimit이 0이면 예외가 발생한다")
+        fun `throw exception when monthlyTokenLimit is zero`() {
             assertThatThrownBy {
                 Plan.create(
-                    planCode = PlanCode.PRO,
+                    planCode = PlanCode.ENTERPRISE,
                     maxSeats = 10,
-                    monthlyTokenLimit = -1L
+                    monthlyTokenLimit = 0L
                 )
             }.isInstanceOf(PlanException::class.java)
                 .extracting("errorCode")
@@ -61,31 +91,31 @@ class PlanTest {
         }
 
         @Test
-        @DisplayName("maxSeats가 0이면 생성할 수 있다")
-        fun `create plan with zero maxSeats`() {
-            // When
-            val plan = Plan.create(
-                planCode = PlanCode.FREE,
-                maxSeats = 0,
-                monthlyTokenLimit = 1000L
-            )
-
-            // Then
-            assertThat(plan.maxSeats).isEqualTo(0)
+        @DisplayName("FREE 플랜에서 maxSeats가 1이 아니면 예외가 발생한다")
+        fun `throw exception when free plan maxSeats is not 1`() {
+            assertThatThrownBy {
+                Plan.create(
+                    planCode = PlanCode.FREE,
+                    maxSeats = 2,
+                    monthlyTokenLimit = 10_000L
+                )
+            }.isInstanceOf(PlanException::class.java)
+                .extracting("errorCode")
+                .isEqualTo(PlanErrorCode.INVALID_MAX_SEATS_FOR_PLAN)
         }
 
         @Test
-        @DisplayName("monthlyTokenLimit이 0이면 생성할 수 있다")
-        fun `create plan with zero monthlyTokenLimit`() {
-            // When
-            val plan = Plan.create(
-                planCode = PlanCode.FREE,
-                maxSeats = 1,
-                monthlyTokenLimit = 0L
-            )
-
-            // Then
-            assertThat(plan.monthlyTokenLimit).isEqualTo(0L)
+        @DisplayName("PRO 플랜에서 maxSeats가 1이 아니면 예외가 발생한다")
+        fun `throw exception when pro plan maxSeats is not 1`() {
+            assertThatThrownBy {
+                Plan.create(
+                    planCode = PlanCode.PRO,
+                    maxSeats = 5,
+                    monthlyTokenLimit = 100_000L
+                )
+            }.isInstanceOf(PlanException::class.java)
+                .extracting("errorCode")
+                .isEqualTo(PlanErrorCode.INVALID_MAX_SEATS_FOR_PLAN)
         }
 
     }
@@ -95,11 +125,11 @@ class PlanTest {
     inner class Update {
 
         @Test
-        @DisplayName("플랜을 수정할 수 있다")
-        fun `update plan successfully`() {
+        @DisplayName("ENTERPRISE 플랜을 수정할 수 있다")
+        fun `update enterprise plan successfully`() {
             // Given
             val plan = Plan.create(
-                planCode = PlanCode.PRO,
+                planCode = PlanCode.ENTERPRISE,
                 maxSeats = 5,
                 monthlyTokenLimit = 100_000L
             )
@@ -115,73 +145,74 @@ class PlanTest {
         }
 
         @Test
-        @DisplayName("수정 시 maxSeats가 음수이면 예외가 발생한다")
-        fun `throw exception when update with negative maxSeats`() {
+        @DisplayName("FREE/PRO 플랜은 monthlyTokenLimit만 수정할 수 있다")
+        fun `update free pro plan monthlyTokenLimit only`() {
             // Given
             val plan = Plan.create(
                 planCode = PlanCode.PRO,
+                maxSeats = 1,
+                monthlyTokenLimit = 100_000L
+            )
+
+            // When
+            val updated = plan.update(maxSeats = 1, monthlyTokenLimit = 500_000L)
+
+            // Then
+            assertThat(updated.monthlyTokenLimit).isEqualTo(500_000L)
+        }
+
+        @Test
+        @DisplayName("수정 시 maxSeats가 0이면 예외가 발생한다")
+        fun `throw exception when update with zero maxSeats`() {
+            // Given
+            val plan = Plan.create(
+                planCode = PlanCode.ENTERPRISE,
                 maxSeats = 10,
                 monthlyTokenLimit = 100_000L
             )
 
             // When & Then
             assertThatThrownBy {
-                plan.update(maxSeats = -1, monthlyTokenLimit = 100_000L)
+                plan.update(maxSeats = 0, monthlyTokenLimit = 100_000L)
             }.isInstanceOf(PlanException::class.java)
                 .extracting("errorCode")
                 .isEqualTo(PlanErrorCode.INVALID_MAX_SEATS)
         }
 
         @Test
-        @DisplayName("수정 시 monthlyTokenLimit이 음수이면 예외가 발생한다")
-        fun `throw exception when update with negative monthlyTokenLimit`() {
+        @DisplayName("수정 시 monthlyTokenLimit이 0이면 예외가 발생한다")
+        fun `throw exception when update with zero monthlyTokenLimit`() {
             // Given
             val plan = Plan.create(
-                planCode = PlanCode.PRO,
+                planCode = PlanCode.ENTERPRISE,
                 maxSeats = 10,
                 monthlyTokenLimit = 100_000L
             )
 
             // When & Then
             assertThatThrownBy {
-                plan.update(maxSeats = 10, monthlyTokenLimit = -1L)
+                plan.update(maxSeats = 10, monthlyTokenLimit = 0L)
             }.isInstanceOf(PlanException::class.java)
                 .extracting("errorCode")
                 .isEqualTo(PlanErrorCode.INVALID_MONTHLY_TOKEN_LIMIT)
         }
 
         @Test
-        @DisplayName("수정 시 maxSeats를 0으로 변경할 수 있다")
-        fun `update plan with zero maxSeats`() {
+        @DisplayName("FREE/PRO 플랜에서 maxSeats를 1이 아닌 값으로 수정하면 예외가 발생한다")
+        fun `throw exception when update free pro plan with maxSeats not 1`() {
             // Given
             val plan = Plan.create(
                 planCode = PlanCode.PRO,
-                maxSeats = 10,
+                maxSeats = 1,
                 monthlyTokenLimit = 100_000L
             )
 
-            // When
-            val updated = plan.update(maxSeats = 0, monthlyTokenLimit = 100_000L)
-
-            // Then
-            assertThat(updated.maxSeats).isEqualTo(0)
-        }
-
-        @Test
-        @DisplayName("수정 시 monthlyTokenLimit을 0으로 변경할 수 있다")
-        fun `update plan with zero monthlyTokenLimit`() {
-            // Given
-            val plan = Plan.create(
-                planCode = PlanCode.PRO,
-                maxSeats = 10,
-                monthlyTokenLimit = 100_000L
-            )
-
-            // When
-            val updated = plan.update(maxSeats = 10, monthlyTokenLimit = 0L)
-
-            // Then
-            assertThat(updated.monthlyTokenLimit).isEqualTo(0L)
+            // When & Then
+            assertThatThrownBy {
+                plan.update(maxSeats = 5, monthlyTokenLimit = 100_000L)
+            }.isInstanceOf(PlanException::class.java)
+                .extracting("errorCode")
+                .isEqualTo(PlanErrorCode.INVALID_MAX_SEATS_FOR_PLAN)
         }
     }
 
@@ -194,7 +225,7 @@ class PlanTest {
         fun `delete plan sets deleted to true`() {
             // Given
             val plan = Plan.create(
-                planCode = PlanCode.PRO,
+                planCode = PlanCode.ENTERPRISE,
                 maxSeats = 10,
                 monthlyTokenLimit = 100_000L
             )
@@ -213,7 +244,7 @@ class PlanTest {
         fun `throw exception when delete already deleted plan`() {
             // Given
             val plan = Plan.create(
-                planCode = PlanCode.PRO,
+                planCode = PlanCode.ENTERPRISE,
                 maxSeats = 10,
                 monthlyTokenLimit = 100_000L
             )
@@ -232,7 +263,7 @@ class PlanTest {
         fun `throw exception when update deleted plan`() {
             // Given
             val plan = Plan.create(
-                planCode = PlanCode.PRO,
+                planCode = PlanCode.ENTERPRISE,
                 maxSeats = 10,
                 monthlyTokenLimit = 100_000L
             )
@@ -287,7 +318,7 @@ class PlanTest {
             // When
             val plan = Plan.reconstitute(
                 id = id,
-                planCode = PlanCode.PRO,
+                planCode = PlanCode.ENTERPRISE,
                 maxSeats = 10,
                 monthlyTokenLimit = 100_000L,
                 deleted = true
@@ -298,35 +329,43 @@ class PlanTest {
         }
 
         @Test
-        @DisplayName("복원 시 maxSeats가 음수이면 예외가 발생한다")
-        fun `throw exception when reconstitute with negative maxSeats`() {
-            assertThatThrownBy {
-                Plan.reconstitute(
-                    id = PlanId.generate(),
-                    planCode = PlanCode.PRO,
-                    maxSeats = -1,
-                    monthlyTokenLimit = 100_000L,
-                    deleted = false
-                )
-            }.isInstanceOf(PlanException::class.java)
-                .extracting("errorCode")
-                .isEqualTo(PlanErrorCode.INVALID_MAX_SEATS)
+        @DisplayName("복원 시 검증을 수행하지 않는다 - 잘못된 데이터도 복원 가능")
+        fun `reconstitute skips validation for invalid data`() {
+            // Given - 잘못된 데이터 (maxSeats=0)
+            val id = PlanId.generate()
+
+            // When - 복원은 성공
+            val plan = Plan.reconstitute(
+                id = id,
+                planCode = PlanCode.ENTERPRISE,
+                maxSeats = 0,
+                monthlyTokenLimit = 0L,
+                deleted = false
+            )
+
+            // Then
+            assertThat(plan.maxSeats).isEqualTo(0)
+            assertThat(plan.monthlyTokenLimit).isEqualTo(0L)
         }
 
         @Test
-        @DisplayName("복원 시 monthlyTokenLimit이 음수이면 예외가 발생한다")
-        fun `throw exception when reconstitute with negative monthlyTokenLimit`() {
+        @DisplayName("복원된 잘못된 데이터를 수정하려 하면 검증 실패")
+        fun `update on reconstituted invalid data fails validation`() {
+            // Given - 잘못된 데이터로 복원
+            val plan = Plan.reconstitute(
+                id = PlanId.generate(),
+                planCode = PlanCode.ENTERPRISE,
+                maxSeats = 0,
+                monthlyTokenLimit = 100_000L,
+                deleted = false
+            )
+
+            // When & Then - 수정 시 검증 실패
             assertThatThrownBy {
-                Plan.reconstitute(
-                    id = PlanId.generate(),
-                    planCode = PlanCode.PRO,
-                    maxSeats = 10,
-                    monthlyTokenLimit = -1L,
-                    deleted = false
-                )
+                plan.update(maxSeats = 0, monthlyTokenLimit = 100_000L)
             }.isInstanceOf(PlanException::class.java)
                 .extracting("errorCode")
-                .isEqualTo(PlanErrorCode.INVALID_MONTHLY_TOKEN_LIMIT)
+                .isEqualTo(PlanErrorCode.INVALID_MAX_SEATS)
         }
     }
 }

--- a/src/test/kotlin/com/flab/license/domain/plan/PlanTest.kt
+++ b/src/test/kotlin/com/flab/license/domain/plan/PlanTest.kt
@@ -1,0 +1,332 @@
+package com.flab.license.domain.plan
+
+import com.flab.license.domain.plan.exception.PlanErrorCode
+import com.flab.license.domain.plan.exception.PlanException
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class PlanTest {
+
+    @Nested
+    @DisplayName("create")
+    inner class Create {
+
+        @Test
+        @DisplayName("플랜을 생성할 수 있다")
+        fun `create plan successfully`() {
+            // When
+            val plan = Plan.create(
+                planCode = PlanCode.PRO,
+                maxSeats = 10,
+                monthlyTokenLimit = 100_000L
+            )
+
+            // Then
+            assertThat(plan.id).isNotNull
+            assertThat(plan.planCode).isEqualTo(PlanCode.PRO)
+            assertThat(plan.maxSeats).isEqualTo(10)
+            assertThat(plan.monthlyTokenLimit).isEqualTo(100_000L)
+            assertThat(plan.deleted).isFalse
+        }
+
+        @Test
+        @DisplayName("maxSeats가 음수이면 예외가 발생한다")
+        fun `throw exception when maxSeats is negative`() {
+            assertThatThrownBy {
+                Plan.create(
+                    planCode = PlanCode.PRO,
+                    maxSeats = -1,
+                    monthlyTokenLimit = 100_000L
+                )
+            }.isInstanceOf(PlanException::class.java)
+                .extracting("errorCode")
+                .isEqualTo(PlanErrorCode.INVALID_MAX_SEATS)
+        }
+
+        @Test
+        @DisplayName("monthlyTokenLimit이 음수이면 예외가 발생한다")
+        fun `throw exception when monthlyTokenLimit is negative`() {
+            assertThatThrownBy {
+                Plan.create(
+                    planCode = PlanCode.PRO,
+                    maxSeats = 10,
+                    monthlyTokenLimit = -1L
+                )
+            }.isInstanceOf(PlanException::class.java)
+                .extracting("errorCode")
+                .isEqualTo(PlanErrorCode.INVALID_MONTHLY_TOKEN_LIMIT)
+        }
+
+        @Test
+        @DisplayName("maxSeats가 0이면 생성할 수 있다")
+        fun `create plan with zero maxSeats`() {
+            // When
+            val plan = Plan.create(
+                planCode = PlanCode.FREE,
+                maxSeats = 0,
+                monthlyTokenLimit = 1000L
+            )
+
+            // Then
+            assertThat(plan.maxSeats).isEqualTo(0)
+        }
+
+        @Test
+        @DisplayName("monthlyTokenLimit이 0이면 생성할 수 있다")
+        fun `create plan with zero monthlyTokenLimit`() {
+            // When
+            val plan = Plan.create(
+                planCode = PlanCode.FREE,
+                maxSeats = 1,
+                monthlyTokenLimit = 0L
+            )
+
+            // Then
+            assertThat(plan.monthlyTokenLimit).isEqualTo(0L)
+        }
+
+    }
+
+    @Nested
+    @DisplayName("update")
+    inner class Update {
+
+        @Test
+        @DisplayName("플랜을 수정할 수 있다")
+        fun `update plan successfully`() {
+            // Given
+            val plan = Plan.create(
+                planCode = PlanCode.PRO,
+                maxSeats = 5,
+                monthlyTokenLimit = 100_000L
+            )
+
+            // When
+            val updated = plan.update(maxSeats = 10, monthlyTokenLimit = 500_000L)
+
+            // Then
+            assertThat(updated.id).isEqualTo(plan.id)
+            assertThat(updated.planCode).isEqualTo(plan.planCode)
+            assertThat(updated.maxSeats).isEqualTo(10)
+            assertThat(updated.monthlyTokenLimit).isEqualTo(500_000L)
+        }
+
+        @Test
+        @DisplayName("수정 시 maxSeats가 음수이면 예외가 발생한다")
+        fun `throw exception when update with negative maxSeats`() {
+            // Given
+            val plan = Plan.create(
+                planCode = PlanCode.PRO,
+                maxSeats = 10,
+                monthlyTokenLimit = 100_000L
+            )
+
+            // When & Then
+            assertThatThrownBy {
+                plan.update(maxSeats = -1, monthlyTokenLimit = 100_000L)
+            }.isInstanceOf(PlanException::class.java)
+                .extracting("errorCode")
+                .isEqualTo(PlanErrorCode.INVALID_MAX_SEATS)
+        }
+
+        @Test
+        @DisplayName("수정 시 monthlyTokenLimit이 음수이면 예외가 발생한다")
+        fun `throw exception when update with negative monthlyTokenLimit`() {
+            // Given
+            val plan = Plan.create(
+                planCode = PlanCode.PRO,
+                maxSeats = 10,
+                monthlyTokenLimit = 100_000L
+            )
+
+            // When & Then
+            assertThatThrownBy {
+                plan.update(maxSeats = 10, monthlyTokenLimit = -1L)
+            }.isInstanceOf(PlanException::class.java)
+                .extracting("errorCode")
+                .isEqualTo(PlanErrorCode.INVALID_MONTHLY_TOKEN_LIMIT)
+        }
+
+        @Test
+        @DisplayName("수정 시 maxSeats를 0으로 변경할 수 있다")
+        fun `update plan with zero maxSeats`() {
+            // Given
+            val plan = Plan.create(
+                planCode = PlanCode.PRO,
+                maxSeats = 10,
+                monthlyTokenLimit = 100_000L
+            )
+
+            // When
+            val updated = plan.update(maxSeats = 0, monthlyTokenLimit = 100_000L)
+
+            // Then
+            assertThat(updated.maxSeats).isEqualTo(0)
+        }
+
+        @Test
+        @DisplayName("수정 시 monthlyTokenLimit을 0으로 변경할 수 있다")
+        fun `update plan with zero monthlyTokenLimit`() {
+            // Given
+            val plan = Plan.create(
+                planCode = PlanCode.PRO,
+                maxSeats = 10,
+                monthlyTokenLimit = 100_000L
+            )
+
+            // When
+            val updated = plan.update(maxSeats = 10, monthlyTokenLimit = 0L)
+
+            // Then
+            assertThat(updated.monthlyTokenLimit).isEqualTo(0L)
+        }
+    }
+
+    @Nested
+    @DisplayName("delete")
+    inner class Delete {
+
+        @Test
+        @DisplayName("플랜을 삭제하면 deleted가 true가 된다")
+        fun `delete plan sets deleted to true`() {
+            // Given
+            val plan = Plan.create(
+                planCode = PlanCode.PRO,
+                maxSeats = 10,
+                monthlyTokenLimit = 100_000L
+            )
+
+            // When
+            val deleted = plan.delete()
+
+            // Then
+            assertThat(deleted.deleted).isTrue
+            assertThat(deleted.id).isEqualTo(plan.id)
+            assertThat(deleted.planCode).isEqualTo(plan.planCode)
+        }
+
+        @Test
+        @DisplayName("이미 삭제된 플랜을 다시 삭제하면 예외가 발생한다")
+        fun `throw exception when delete already deleted plan`() {
+            // Given
+            val plan = Plan.create(
+                planCode = PlanCode.PRO,
+                maxSeats = 10,
+                monthlyTokenLimit = 100_000L
+            )
+            val deletedPlan = plan.delete()
+
+            // When & Then
+            assertThatThrownBy {
+                deletedPlan.delete()
+            }.isInstanceOf(PlanException::class.java)
+                .extracting("errorCode")
+                .isEqualTo(PlanErrorCode.PLAN_ALREADY_DELETED)
+        }
+
+        @Test
+        @DisplayName("삭제된 플랜을 수정하면 예외가 발생한다")
+        fun `throw exception when update deleted plan`() {
+            // Given
+            val plan = Plan.create(
+                planCode = PlanCode.PRO,
+                maxSeats = 10,
+                monthlyTokenLimit = 100_000L
+            )
+            val deletedPlan = plan.delete()
+
+            // When & Then
+            assertThatThrownBy {
+                deletedPlan.update(maxSeats = 20, monthlyTokenLimit = 200_000L)
+            }.isInstanceOf(PlanException::class.java)
+                .extracting("errorCode")
+                .isEqualTo(PlanErrorCode.PLAN_ALREADY_DELETED)
+        }
+    }
+
+    @Nested
+    @DisplayName("reconstitute")
+    inner class Reconstitute {
+
+        @Test
+        @DisplayName("저장된 플랜을 복원할 수 있다")
+        fun `reconstitute plan successfully`() {
+            // Given
+            val id = PlanId.generate()
+            val planCode = PlanCode.ENTERPRISE
+            val maxSeats = 100
+            val monthlyTokenLimit = 1_000_000L
+            val deleted = false
+
+            // When
+            val plan = Plan.reconstitute(
+                id = id,
+                planCode = planCode,
+                maxSeats = maxSeats,
+                monthlyTokenLimit = monthlyTokenLimit,
+                deleted = deleted
+            )
+
+            // Then
+            assertThat(plan.id).isEqualTo(id)
+            assertThat(plan.planCode).isEqualTo(planCode)
+            assertThat(plan.maxSeats).isEqualTo(maxSeats)
+            assertThat(plan.monthlyTokenLimit).isEqualTo(monthlyTokenLimit)
+            assertThat(plan.deleted).isEqualTo(deleted)
+        }
+
+        @Test
+        @DisplayName("삭제된 플랜도 복원할 수 있다")
+        fun `reconstitute deleted plan`() {
+            // Given
+            val id = PlanId.generate()
+
+            // When
+            val plan = Plan.reconstitute(
+                id = id,
+                planCode = PlanCode.PRO,
+                maxSeats = 10,
+                monthlyTokenLimit = 100_000L,
+                deleted = true
+            )
+
+            // Then
+            assertThat(plan.deleted).isTrue
+        }
+
+        @Test
+        @DisplayName("복원 시 maxSeats가 음수이면 예외가 발생한다")
+        fun `throw exception when reconstitute with negative maxSeats`() {
+            assertThatThrownBy {
+                Plan.reconstitute(
+                    id = PlanId.generate(),
+                    planCode = PlanCode.PRO,
+                    maxSeats = -1,
+                    monthlyTokenLimit = 100_000L,
+                    deleted = false
+                )
+            }.isInstanceOf(PlanException::class.java)
+                .extracting("errorCode")
+                .isEqualTo(PlanErrorCode.INVALID_MAX_SEATS)
+        }
+
+        @Test
+        @DisplayName("복원 시 monthlyTokenLimit이 음수이면 예외가 발생한다")
+        fun `throw exception when reconstitute with negative monthlyTokenLimit`() {
+            assertThatThrownBy {
+                Plan.reconstitute(
+                    id = PlanId.generate(),
+                    planCode = PlanCode.PRO,
+                    maxSeats = 10,
+                    monthlyTokenLimit = -1L,
+                    deleted = false
+                )
+            }.isInstanceOf(PlanException::class.java)
+                .extracting("errorCode")
+                .isEqualTo(PlanErrorCode.INVALID_MONTHLY_TOKEN_LIMIT)
+        }
+    }
+}

--- a/src/test/kotlin/com/flab/license/infra/persistence/plan/jpa/PlanJpaEntityTest.kt
+++ b/src/test/kotlin/com/flab/license/infra/persistence/plan/jpa/PlanJpaEntityTest.kt
@@ -2,12 +2,11 @@ package com.flab.license.infra.persistence.plan.jpa
 
 import com.flab.license.domain.plan.Plan
 import com.flab.license.domain.plan.PlanCode
-import com.flab.license.domain.plan.PlanId
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import java.util.UUID
+import java.util.*
 
 class PlanJpaEntityTest {
 
@@ -20,7 +19,7 @@ class PlanJpaEntityTest {
         fun `convert domain to entity`() {
             // Given
             val plan = Plan.create(
-                planCode = PlanCode.PRO,
+                planCode = PlanCode.ENTERPRISE,
                 maxSeats = 10,
                 monthlyTokenLimit = 500_000L
             )
@@ -88,7 +87,7 @@ class PlanJpaEntityTest {
             // Given
             val entity = PlanJpaEntity(
                 id = UUID.randomUUID(),
-                planCode = PlanCode.PRO,
+                planCode = PlanCode.ENTERPRISE,
                 maxSeats = 10,
                 monthlyTokenLimit = 500_000L,
                 deleted = true
@@ -111,7 +110,7 @@ class PlanJpaEntityTest {
         fun `domain to entity to domain preserves data`() {
             // Given
             val original = Plan.create(
-                planCode = PlanCode.PRO,
+                planCode = PlanCode.ENTERPRISE,
                 maxSeats = 10,
                 monthlyTokenLimit = 500_000L
             )

--- a/src/test/kotlin/com/flab/license/infra/persistence/plan/jpa/PlanJpaEntityTest.kt
+++ b/src/test/kotlin/com/flab/license/infra/persistence/plan/jpa/PlanJpaEntityTest.kt
@@ -1,0 +1,131 @@
+package com.flab.license.infra.persistence.plan.jpa
+
+import com.flab.license.domain.plan.Plan
+import com.flab.license.domain.plan.PlanCode
+import com.flab.license.domain.plan.PlanId
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.util.UUID
+
+class PlanJpaEntityTest {
+
+    @Nested
+    @DisplayName("fromDomain")
+    inner class FromDomain {
+
+        @Test
+        @DisplayName("도메인 객체를 JPA 엔티티로 변환할 수 있다")
+        fun `convert domain to entity`() {
+            // Given
+            val plan = Plan.create(
+                planCode = PlanCode.PRO,
+                maxSeats = 10,
+                monthlyTokenLimit = 500_000L
+            )
+
+            // When
+            val entity = PlanJpaEntity.fromDomain(plan)
+
+            // Then
+            assertThat(entity.id).isEqualTo(plan.id.value)
+            assertThat(entity.planCode).isEqualTo(plan.planCode)
+            assertThat(entity.maxSeats).isEqualTo(plan.maxSeats)
+            assertThat(entity.monthlyTokenLimit).isEqualTo(plan.monthlyTokenLimit)
+            assertThat(entity.deleted).isEqualTo(plan.deleted)
+        }
+
+        @Test
+        @DisplayName("삭제된 도메인 객체도 변환할 수 있다")
+        fun `convert deleted domain to entity`() {
+            // Given
+            val plan = Plan.create(
+                planCode = PlanCode.FREE,
+                maxSeats = 1,
+                monthlyTokenLimit = 50_000L
+            ).delete()
+
+            // When
+            val entity = PlanJpaEntity.fromDomain(plan)
+
+            // Then
+            assertThat(entity.deleted).isTrue()
+        }
+    }
+
+    @Nested
+    @DisplayName("toDomain")
+    inner class ToDomain {
+
+        @Test
+        @DisplayName("JPA 엔티티를 도메인 객체로 변환할 수 있다")
+        fun `convert entity to domain`() {
+            // Given
+            val id = UUID.randomUUID()
+            val entity = PlanJpaEntity(
+                id = id,
+                planCode = PlanCode.ENTERPRISE,
+                maxSeats = 100,
+                monthlyTokenLimit = 5_000_000L,
+                deleted = false
+            )
+
+            // When
+            val plan = entity.toDomain()
+
+            // Then
+            assertThat(plan.id.value).isEqualTo(id)
+            assertThat(plan.planCode).isEqualTo(PlanCode.ENTERPRISE)
+            assertThat(plan.maxSeats).isEqualTo(100)
+            assertThat(plan.monthlyTokenLimit).isEqualTo(5_000_000L)
+            assertThat(plan.deleted).isFalse()
+        }
+
+        @Test
+        @DisplayName("삭제된 엔티티도 도메인 객체로 변환할 수 있다")
+        fun `convert deleted entity to domain`() {
+            // Given
+            val entity = PlanJpaEntity(
+                id = UUID.randomUUID(),
+                planCode = PlanCode.PRO,
+                maxSeats = 10,
+                monthlyTokenLimit = 500_000L,
+                deleted = true
+            )
+
+            // When
+            val plan = entity.toDomain()
+
+            // Then
+            assertThat(plan.deleted).isTrue()
+        }
+    }
+
+    @Nested
+    @DisplayName("roundTrip")
+    inner class RoundTrip {
+
+        @Test
+        @DisplayName("도메인 -> 엔티티 -> 도메인 변환 시 데이터가 유지된다")
+        fun `domain to entity to domain preserves data`() {
+            // Given
+            val original = Plan.create(
+                planCode = PlanCode.PRO,
+                maxSeats = 10,
+                monthlyTokenLimit = 500_000L
+            )
+
+            // When
+            val entity = PlanJpaEntity.fromDomain(original)
+            val restored = entity.toDomain()
+
+            // Then
+            assertThat(restored.id).isEqualTo(original.id)
+            assertThat(restored.planCode).isEqualTo(original.planCode)
+            assertThat(restored.maxSeats).isEqualTo(original.maxSeats)
+            assertThat(restored.monthlyTokenLimit).isEqualTo(original.monthlyTokenLimit)
+            assertThat(restored.deleted).isEqualTo(original.deleted)
+        }
+    }
+}

--- a/src/test/kotlin/com/flab/license/infra/persistence/plan/jpa/PlanJpaMapperTest.kt
+++ b/src/test/kotlin/com/flab/license/infra/persistence/plan/jpa/PlanJpaMapperTest.kt
@@ -8,11 +8,11 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import java.util.*
 
-class PlanJpaEntityTest {
+class PlanJpaMapperTest {
 
     @Nested
-    @DisplayName("fromDomain")
-    inner class FromDomain {
+    @DisplayName("toEntity")
+    inner class ToEntity {
 
         @Test
         @DisplayName("도메인 객체를 JPA 엔티티로 변환할 수 있다")
@@ -25,7 +25,7 @@ class PlanJpaEntityTest {
             )
 
             // When
-            val entity = PlanJpaEntity.fromDomain(plan)
+            val entity = plan.toEntity()
 
             // Then
             assertThat(entity.id).isEqualTo(plan.id.value)
@@ -46,7 +46,7 @@ class PlanJpaEntityTest {
             ).delete()
 
             // When
-            val entity = PlanJpaEntity.fromDomain(plan)
+            val entity = plan.toEntity()
 
             // Then
             assertThat(entity.deleted).isTrue()
@@ -116,7 +116,7 @@ class PlanJpaEntityTest {
             )
 
             // When
-            val entity = PlanJpaEntity.fromDomain(original)
+            val entity = original.toEntity()
             val restored = entity.toDomain()
 
             // Then

--- a/src/test/kotlin/com/flab/license/infra/persistence/plan/jpa/PlanRepositoryJpaAdapterTest.kt
+++ b/src/test/kotlin/com/flab/license/infra/persistence/plan/jpa/PlanRepositoryJpaAdapterTest.kt
@@ -1,0 +1,315 @@
+package com.flab.license.infra.persistence.plan.jpa
+
+import com.flab.license.common.exception.CommonErrorCode
+import com.flab.license.common.exception.CustomException
+import com.flab.license.domain.plan.Plan
+import com.flab.license.domain.plan.PlanCode
+import com.flab.license.domain.plan.PlanId
+import com.flab.license.domain.plan.PlanRepository
+import com.flab.license.domain.plan.exception.PlanErrorCode
+import com.flab.license.domain.plan.exception.PlanException
+import jakarta.persistence.EntityManager
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import org.springframework.context.annotation.Import
+import com.flab.license.common.config.JpaConfig
+
+@DataJpaTest
+@Import(PlanRepositoryJpaAdapter::class, JpaConfig::class)
+class PlanRepositoryJpaAdapterTest {
+
+    @Autowired
+    private lateinit var planRepository: PlanRepository
+
+    @Autowired
+    private lateinit var springDataJpaRepository: PlanSpringDataJpaRepository
+
+    @Autowired
+    private lateinit var entityManager: EntityManager
+
+    @BeforeEach
+    fun setUp() {
+        springDataJpaRepository.deleteAll()
+        entityManager.flush()
+        entityManager.clear()
+    }
+
+    @Nested
+    @DisplayName("save")
+    inner class Save {
+
+        @Test
+        @DisplayName("플랜을 저장할 수 있다")
+        fun `save plan successfully`() {
+            // Given
+            val plan = Plan.create(
+                planCode = PlanCode.PRO,
+                maxSeats = 10,
+                monthlyTokenLimit = 500_000L
+            )
+
+            // When
+            val saved = planRepository.save(plan)
+
+            // Then
+            assertThat(saved.id).isEqualTo(plan.id)
+            assertThat(saved.planCode).isEqualTo(PlanCode.PRO)
+            assertThat(saved.maxSeats).isEqualTo(10)
+            assertThat(saved.monthlyTokenLimit).isEqualTo(500_000L)
+            assertThat(saved.deleted).isFalse()
+        }
+    }
+
+    @Nested
+    @DisplayName("update")
+    inner class Update {
+
+        @Test
+        @DisplayName("플랜을 수정할 수 있다")
+        fun `update plan successfully`() {
+            // Given
+            val plan = Plan.create(
+                planCode = PlanCode.PRO,
+                maxSeats = 10,
+                monthlyTokenLimit = 500_000L
+            )
+            planRepository.save(plan)
+
+            val updated = plan.update(maxSeats = 20, monthlyTokenLimit = 1_000_000L)
+
+            // When
+            val result = planRepository.update(updated)
+
+            // Then
+            assertThat(result.maxSeats).isEqualTo(20)
+            assertThat(result.monthlyTokenLimit).isEqualTo(1_000_000L)
+        }
+    }
+
+    @Nested
+    @DisplayName("delete")
+    inner class Delete {
+
+        @Test
+        @DisplayName("플랜을 삭제할 수 있다")
+        fun `delete plan successfully`() {
+            // Given
+            val plan = Plan.create(
+                planCode = PlanCode.PRO,
+                maxSeats = 10,
+                monthlyTokenLimit = 500_000L
+            )
+            planRepository.save(plan)
+
+            val deleted = plan.delete()
+
+            // When
+            val result = planRepository.delete(deleted)
+
+            // Then
+            assertThat(result.deleted).isTrue()
+        }
+    }
+
+    @Nested
+    @DisplayName("loadById")
+    inner class LoadById {
+
+        @Test
+        @DisplayName("ID로 플랜을 로드할 수 있다")
+        fun `load plan by id successfully`() {
+            // Given
+            val plan = Plan.create(
+                planCode = PlanCode.PRO,
+                maxSeats = 10,
+                monthlyTokenLimit = 500_000L
+            )
+            planRepository.save(plan)
+
+            // When
+            val result = planRepository.loadById(plan.id)
+
+            // Then
+            assertThat(result.id).isEqualTo(plan.id)
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 ID로 로드하면 예외가 발생한다")
+        fun `throw exception when plan not found`() {
+            // Given
+            val planId = PlanId.generate()
+
+            // When & Then
+            assertThatThrownBy {
+                planRepository.loadById(planId)
+            }.isInstanceOf(PlanException::class.java)
+                .extracting("errorCode")
+                .isEqualTo(PlanErrorCode.PLAN_NOT_FOUND)
+        }
+
+        @Test
+        @DisplayName("삭제된 플랜은 조회되지 않는다")
+        fun `throw exception when plan is deleted`() {
+            // Given
+            val plan = Plan.create(
+                planCode = PlanCode.PRO,
+                maxSeats = 10,
+                monthlyTokenLimit = 500_000L
+            )
+            planRepository.save(plan)
+            planRepository.delete(plan.delete())
+
+            // When & Then
+            assertThatThrownBy {
+                planRepository.loadById(plan.id)
+            }.isInstanceOf(PlanException::class.java)
+                .extracting("errorCode")
+                .isEqualTo(PlanErrorCode.PLAN_NOT_FOUND)
+        }
+    }
+
+    @Nested
+    @DisplayName("loadByPlanCode")
+    inner class LoadByPlanCode {
+
+        @Test
+        @DisplayName("플랜 코드로 플랜을 로드할 수 있다")
+        fun `load plan by plan code successfully`() {
+            // Given
+            val plan = Plan.create(
+                planCode = PlanCode.ENTERPRISE,
+                maxSeats = 100,
+                monthlyTokenLimit = 5_000_000L
+            )
+            planRepository.save(plan)
+
+            // When
+            val result = planRepository.loadByPlanCode(PlanCode.ENTERPRISE)
+
+            // Then
+            assertThat(result.planCode).isEqualTo(PlanCode.ENTERPRISE)
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 플랜 코드로 로드하면 예외가 발생한다")
+        fun `throw exception when plan code not found`() {
+            // When & Then
+            assertThatThrownBy {
+                planRepository.loadByPlanCode(PlanCode.FREE)
+            }.isInstanceOf(PlanException::class.java)
+                .extracting("errorCode")
+                .isEqualTo(PlanErrorCode.PLAN_NOT_FOUND)
+        }
+
+        @Test
+        @DisplayName("삭제된 플랜은 조회되지 않는다")
+        fun `throw exception when plan is deleted`() {
+            // Given
+            val plan = Plan.create(
+                planCode = PlanCode.ENTERPRISE,
+                maxSeats = 100,
+                monthlyTokenLimit = 5_000_000L
+            )
+            planRepository.save(plan)
+            planRepository.delete(plan.delete())
+
+            // When & Then
+            assertThatThrownBy {
+                planRepository.loadByPlanCode(PlanCode.ENTERPRISE)
+            }.isInstanceOf(PlanException::class.java)
+                .extracting("errorCode")
+                .isEqualTo(PlanErrorCode.PLAN_NOT_FOUND)
+        }
+    }
+
+    @Nested
+    @DisplayName("loadAll")
+    inner class LoadAll {
+
+        @Test
+        @DisplayName("전체 플랜 목록을 조회할 수 있다")
+        fun `load all plans successfully`() {
+            // Given
+            val plan1 = Plan.create(
+                planCode = PlanCode.FREE,
+                maxSeats = 1,
+                monthlyTokenLimit = 50_000L
+            )
+            val plan2 = Plan.create(
+                planCode = PlanCode.PRO,
+                maxSeats = 10,
+                monthlyTokenLimit = 500_000L
+            )
+            planRepository.save(plan1)
+            planRepository.save(plan2)
+
+            // When
+            val result = planRepository.loadAll()
+
+            // Then
+            assertThat(result).hasSize(2)
+            assertThat(result.map { it.planCode }).containsExactlyInAnyOrder(PlanCode.FREE, PlanCode.PRO)
+        }
+
+        @Test
+        @DisplayName("삭제된 플랜은 목록에서 제외된다")
+        fun `exclude deleted plans from list`() {
+            // Given
+            val plan1 = Plan.create(
+                planCode = PlanCode.FREE,
+                maxSeats = 1,
+                monthlyTokenLimit = 50_000L
+            )
+            val plan2 = Plan.create(
+                planCode = PlanCode.PRO,
+                maxSeats = 10,
+                monthlyTokenLimit = 500_000L
+            )
+            planRepository.save(plan1)
+            planRepository.save(plan2)
+            planRepository.delete(plan2.delete())
+
+            // When
+            val result = planRepository.loadAll()
+
+            // Then
+            assertThat(result).hasSize(1)
+            assertThat(result[0].planCode).isEqualTo(PlanCode.FREE)
+        }
+
+        @Test
+        @DisplayName("플랜이 없으면 빈 목록을 반환한다")
+        fun `return empty list when no plans exist`() {
+            // When
+            val result = planRepository.loadAll()
+
+            // Then
+            assertThat(result).isEmpty()
+        }
+    }
+
+    @Nested
+    @DisplayName("loadByIdIncludeDeleted")
+    inner class LoadByIdIncludeDeleted {
+
+        @Test
+        @DisplayName("아직 구현되지 않은 기능이므로 예외가 발생한다")
+        fun `throw not implemented exception`() {
+            // Given
+            val planId = PlanId.generate()
+
+            // When & Then
+            assertThatThrownBy {
+                planRepository.loadByIdIncludeDeleted(planId)
+            }.isInstanceOf(CustomException::class.java)
+                .extracting("errorCode")
+                .isEqualTo(CommonErrorCode.NOT_IMPLEMENTED)
+        }
+    }
+}

--- a/src/test/kotlin/com/flab/license/infra/persistence/plan/jpa/PlanRepositoryJpaAdapterTest.kt
+++ b/src/test/kotlin/com/flab/license/infra/persistence/plan/jpa/PlanRepositoryJpaAdapterTest.kt
@@ -49,7 +49,7 @@ class PlanRepositoryJpaAdapterTest {
         fun `save plan successfully`() {
             // Given
             val plan = Plan.create(
-                planCode = PlanCode.PRO,
+                planCode = PlanCode.ENTERPRISE,
                 maxSeats = 10,
                 monthlyTokenLimit = 500_000L
             )
@@ -59,7 +59,7 @@ class PlanRepositoryJpaAdapterTest {
 
             // Then
             assertThat(saved.id).isEqualTo(plan.id)
-            assertThat(saved.planCode).isEqualTo(PlanCode.PRO)
+            assertThat(saved.planCode).isEqualTo(PlanCode.ENTERPRISE)
             assertThat(saved.maxSeats).isEqualTo(10)
             assertThat(saved.monthlyTokenLimit).isEqualTo(500_000L)
             assertThat(saved.deleted).isFalse()
@@ -75,7 +75,7 @@ class PlanRepositoryJpaAdapterTest {
         fun `update plan successfully`() {
             // Given
             val plan = Plan.create(
-                planCode = PlanCode.PRO,
+                planCode = PlanCode.ENTERPRISE,
                 maxSeats = 10,
                 monthlyTokenLimit = 500_000L
             )
@@ -101,7 +101,7 @@ class PlanRepositoryJpaAdapterTest {
         fun `delete plan successfully`() {
             // Given
             val plan = Plan.create(
-                planCode = PlanCode.PRO,
+                planCode = PlanCode.ENTERPRISE,
                 maxSeats = 10,
                 monthlyTokenLimit = 500_000L
             )
@@ -126,7 +126,7 @@ class PlanRepositoryJpaAdapterTest {
         fun `load plan by id successfully`() {
             // Given
             val plan = Plan.create(
-                planCode = PlanCode.PRO,
+                planCode = PlanCode.ENTERPRISE,
                 maxSeats = 10,
                 monthlyTokenLimit = 500_000L
             )
@@ -158,7 +158,7 @@ class PlanRepositoryJpaAdapterTest {
         fun `throw exception when plan is deleted`() {
             // Given
             val plan = Plan.create(
-                planCode = PlanCode.PRO,
+                planCode = PlanCode.ENTERPRISE,
                 maxSeats = 10,
                 monthlyTokenLimit = 500_000L
             )
@@ -242,7 +242,7 @@ class PlanRepositoryJpaAdapterTest {
                 monthlyTokenLimit = 50_000L
             )
             val plan2 = Plan.create(
-                planCode = PlanCode.PRO,
+                planCode = PlanCode.ENTERPRISE,
                 maxSeats = 10,
                 monthlyTokenLimit = 500_000L
             )
@@ -254,7 +254,7 @@ class PlanRepositoryJpaAdapterTest {
 
             // Then
             assertThat(result).hasSize(2)
-            assertThat(result.map { it.planCode }).containsExactlyInAnyOrder(PlanCode.FREE, PlanCode.PRO)
+            assertThat(result.map { it.planCode }).containsExactlyInAnyOrder(PlanCode.FREE, PlanCode.ENTERPRISE)
         }
 
         @Test
@@ -267,7 +267,7 @@ class PlanRepositoryJpaAdapterTest {
                 monthlyTokenLimit = 50_000L
             )
             val plan2 = Plan.create(
-                planCode = PlanCode.PRO,
+                planCode = PlanCode.ENTERPRISE,
                 maxSeats = 10,
                 monthlyTokenLimit = 500_000L
             )

--- a/src/test/kotlin/com/flab/license/service/plan/command/PlanCommandServiceTest.kt
+++ b/src/test/kotlin/com/flab/license/service/plan/command/PlanCommandServiceTest.kt
@@ -1,0 +1,148 @@
+package com.flab.license.service.plan.command
+
+import com.flab.license.domain.plan.Plan
+import com.flab.license.domain.plan.PlanCode
+import com.flab.license.domain.plan.PlanId
+import com.flab.license.domain.plan.PlanRepository
+import com.flab.license.domain.plan.exception.PlanErrorCode
+import com.flab.license.domain.plan.exception.PlanException
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.given
+import org.mockito.kotlin.verify
+
+@ExtendWith(MockitoExtension::class)
+class PlanCommandServiceTest {
+
+    @Mock
+    private lateinit var planRepository: PlanRepository
+
+    private lateinit var planCommandService: PlanCommandService
+
+    @BeforeEach
+    fun setUp() {
+        planCommandService = PlanCommandService(planRepository)
+    }
+
+    @Nested
+    @DisplayName("create")
+    inner class Create {
+
+        @Test
+        @DisplayName("플랜을 생성할 수 있다")
+        fun `create plan successfully`() {
+            // Given
+            val command = CreatePlanCommand(
+                planCode = PlanCode.PRO,
+                maxSeats = 10,
+                monthlyTokenLimit = 500_000L
+            )
+            given(planRepository.save(any())).willAnswer { it.arguments[0] }
+
+            // When
+            val result = planCommandService.create(command)
+
+            // Then
+            assertThat(result.planCode).isEqualTo(PlanCode.PRO)
+            assertThat(result.maxSeats).isEqualTo(10)
+            assertThat(result.monthlyTokenLimit).isEqualTo(500_000L)
+            verify(planRepository).save(any())
+        }
+    }
+
+    @Nested
+    @DisplayName("update")
+    inner class Update {
+
+        @Test
+        @DisplayName("플랜을 수정할 수 있다")
+        fun `update plan successfully`() {
+            // Given
+            val existingPlan = Plan.create(
+                planCode = PlanCode.PRO,
+                maxSeats = 10,
+                monthlyTokenLimit = 500_000L
+            )
+            val command = UpdatePlanCommand(
+                planId = existingPlan.id,
+                maxSeats = 20,
+                monthlyTokenLimit = 1_000_000L
+            )
+            given(planRepository.loadById(existingPlan.id)).willReturn(existingPlan)
+            given(planRepository.update(any())).willAnswer { it.arguments[0] }
+
+            // When
+            val result = planCommandService.update(command)
+
+            // Then
+            assertThat(result.maxSeats).isEqualTo(20)
+            assertThat(result.monthlyTokenLimit).isEqualTo(1_000_000L)
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 플랜을 수정하면 예외가 발생한다")
+        fun `throw exception when plan not found`() {
+            // Given
+            val command = UpdatePlanCommand(
+                planId = PlanId.generate(),
+                maxSeats = 20,
+                monthlyTokenLimit = 1_000_000L
+            )
+            given(planRepository.loadById(command.planId)).willThrow(PlanException(PlanErrorCode.PLAN_NOT_FOUND))
+
+            // When & Then
+            assertThatThrownBy {
+                planCommandService.update(command)
+            }.isInstanceOf(PlanException::class.java)
+                .extracting("errorCode")
+                .isEqualTo(PlanErrorCode.PLAN_NOT_FOUND)
+        }
+    }
+
+    @Nested
+    @DisplayName("delete")
+    inner class Delete {
+
+        @Test
+        @DisplayName("플랜을 삭제할 수 있다")
+        fun `delete plan successfully`() {
+            // Given
+            val existingPlan = Plan.create(
+                planCode = PlanCode.PRO,
+                maxSeats = 10,
+                monthlyTokenLimit = 500_000L
+            )
+            given(planRepository.loadById(existingPlan.id)).willReturn(existingPlan)
+            given(planRepository.delete(any())).willAnswer { it.arguments[0] }
+
+            // When
+            val result = planCommandService.delete(existingPlan.id)
+
+            // Then
+            assertThat(result.deleted).isTrue()
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 플랜을 삭제하면 예외가 발생한다")
+        fun `throw exception when plan not found`() {
+            // Given
+            val planId = PlanId.generate()
+            given(planRepository.loadById(planId)).willThrow(PlanException(PlanErrorCode.PLAN_NOT_FOUND))
+
+            // When & Then
+            assertThatThrownBy {
+                planCommandService.delete(planId)
+            }.isInstanceOf(PlanException::class.java)
+                .extracting("errorCode")
+                .isEqualTo(PlanErrorCode.PLAN_NOT_FOUND)
+        }
+    }
+}

--- a/src/test/kotlin/com/flab/license/service/plan/command/PlanCommandServiceTest.kt
+++ b/src/test/kotlin/com/flab/license/service/plan/command/PlanCommandServiceTest.kt
@@ -124,10 +124,10 @@ class PlanCommandServiceTest {
             given(planRepository.delete(any())).willAnswer { it.arguments[0] }
 
             // When
-            val result = planCommandService.delete(existingPlan.id)
+            planCommandService.delete(existingPlan.id)
 
             // Then
-            assertThat(result.deleted).isTrue()
+            verify(planRepository).delete(any())
         }
 
         @Test

--- a/src/test/kotlin/com/flab/license/service/plan/command/PlanCommandServiceTest.kt
+++ b/src/test/kotlin/com/flab/license/service/plan/command/PlanCommandServiceTest.kt
@@ -41,7 +41,7 @@ class PlanCommandServiceTest {
         fun `create plan successfully`() {
             // Given
             val command = CreatePlanCommand(
-                planCode = PlanCode.PRO,
+                planCode = PlanCode.ENTERPRISE,
                 maxSeats = 10,
                 monthlyTokenLimit = 500_000L
             )
@@ -51,7 +51,7 @@ class PlanCommandServiceTest {
             val result = planCommandService.create(command)
 
             // Then
-            assertThat(result.planCode).isEqualTo(PlanCode.PRO)
+            assertThat(result.planCode).isEqualTo(PlanCode.ENTERPRISE)
             assertThat(result.maxSeats).isEqualTo(10)
             assertThat(result.monthlyTokenLimit).isEqualTo(500_000L)
             verify(planRepository).save(any())
@@ -67,7 +67,7 @@ class PlanCommandServiceTest {
         fun `update plan successfully`() {
             // Given
             val existingPlan = Plan.create(
-                planCode = PlanCode.PRO,
+                planCode = PlanCode.ENTERPRISE,
                 maxSeats = 10,
                 monthlyTokenLimit = 500_000L
             )
@@ -116,7 +116,7 @@ class PlanCommandServiceTest {
         fun `delete plan successfully`() {
             // Given
             val existingPlan = Plan.create(
-                planCode = PlanCode.PRO,
+                planCode = PlanCode.ENTERPRISE,
                 maxSeats = 10,
                 monthlyTokenLimit = 500_000L
             )

--- a/src/test/kotlin/com/flab/license/service/plan/query/PlanQueryServiceTest.kt
+++ b/src/test/kotlin/com/flab/license/service/plan/query/PlanQueryServiceTest.kt
@@ -1,0 +1,150 @@
+package com.flab.license.service.plan.query
+
+import com.flab.license.domain.plan.Plan
+import com.flab.license.domain.plan.PlanCode
+import com.flab.license.domain.plan.PlanId
+import com.flab.license.domain.plan.PlanRepository
+import com.flab.license.domain.plan.exception.PlanErrorCode
+import com.flab.license.domain.plan.exception.PlanException
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.given
+
+@ExtendWith(MockitoExtension::class)
+class PlanQueryServiceTest {
+
+    @Mock
+    private lateinit var planRepository: PlanRepository
+
+    private lateinit var planQueryService: PlanQueryService
+
+    @BeforeEach
+    fun setUp() {
+        planQueryService = PlanQueryService(planRepository)
+    }
+
+    @Nested
+    @DisplayName("getById")
+    inner class GetById {
+
+        @Test
+        @DisplayName("ID로 플랜을 조회할 수 있다")
+        fun `get plan by id successfully`() {
+            // Given
+            val plan = Plan.create(
+                planCode = PlanCode.PRO,
+                maxSeats = 10,
+                monthlyTokenLimit = 500_000L
+            )
+            given(planRepository.loadById(plan.id)).willReturn(plan)
+
+            // When
+            val result = planQueryService.getById(plan.id)
+
+            // Then
+            assertThat(result.id).isEqualTo(plan.id)
+            assertThat(result.planCode).isEqualTo(PlanCode.PRO)
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 ID로 조회하면 예외가 발생한다")
+        fun `throw exception when plan not found`() {
+            // Given
+            val planId = PlanId.generate()
+            given(planRepository.loadById(planId)).willThrow(PlanException(PlanErrorCode.PLAN_NOT_FOUND))
+
+            // When & Then
+            assertThatThrownBy {
+                planQueryService.getById(planId)
+            }.isInstanceOf(PlanException::class.java)
+                .extracting("errorCode")
+                .isEqualTo(PlanErrorCode.PLAN_NOT_FOUND)
+        }
+    }
+
+    @Nested
+    @DisplayName("getByPlanCode")
+    inner class GetByPlanCode {
+
+        @Test
+        @DisplayName("플랜 코드로 플랜을 조회할 수 있다")
+        fun `get plan by plan code successfully`() {
+            // Given
+            val plan = Plan.create(
+                planCode = PlanCode.FREE,
+                maxSeats = 1,
+                monthlyTokenLimit = 50_000L
+            )
+            given(planRepository.loadByPlanCode(PlanCode.FREE)).willReturn(plan)
+
+            // When
+            val result = planQueryService.getByPlanCode(PlanCode.FREE)
+
+            // Then
+            assertThat(result.planCode).isEqualTo(PlanCode.FREE)
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 플랜 코드로 조회하면 예외가 발생한다")
+        fun `throw exception when plan code not found`() {
+            // Given
+            given(planRepository.loadByPlanCode(PlanCode.ENTERPRISE)).willThrow(PlanException(PlanErrorCode.PLAN_NOT_FOUND))
+
+            // When & Then
+            assertThatThrownBy {
+                planQueryService.getByPlanCode(PlanCode.ENTERPRISE)
+            }.isInstanceOf(PlanException::class.java)
+                .extracting("errorCode")
+                .isEqualTo(PlanErrorCode.PLAN_NOT_FOUND)
+        }
+    }
+
+    @Nested
+    @DisplayName("getAll")
+    inner class GetAll {
+
+        @Test
+        @DisplayName("전체 플랜 목록을 조회할 수 있다")
+        fun `get all plans successfully`() {
+            // Given
+            val plan1 = Plan.create(
+                planCode = PlanCode.FREE,
+                maxSeats = 1,
+                monthlyTokenLimit = 50_000L
+            )
+            val plan2 = Plan.create(
+                planCode = PlanCode.PRO,
+                maxSeats = 10,
+                monthlyTokenLimit = 500_000L
+            )
+            given(planRepository.loadAll()).willReturn(listOf(plan1, plan2))
+
+            // When
+            val result = planQueryService.getAll()
+
+            // Then
+            assertThat(result).hasSize(2)
+            assertThat(result.map { it.planCode }).containsExactlyInAnyOrder(PlanCode.FREE, PlanCode.PRO)
+        }
+
+        @Test
+        @DisplayName("플랜이 없으면 빈 목록을 반환한다")
+        fun `return empty list when no plans exist`() {
+            // Given
+            given(planRepository.loadAll()).willReturn(emptyList())
+
+            // When
+            val result = planQueryService.getAll()
+
+            // Then
+            assertThat(result).isEmpty()
+        }
+    }
+}

--- a/src/test/kotlin/com/flab/license/service/plan/query/PlanQueryServiceTest.kt
+++ b/src/test/kotlin/com/flab/license/service/plan/query/PlanQueryServiceTest.kt
@@ -39,7 +39,7 @@ class PlanQueryServiceTest {
         fun `get plan by id successfully`() {
             // Given
             val plan = Plan.create(
-                planCode = PlanCode.PRO,
+                planCode = PlanCode.ENTERPRISE,
                 maxSeats = 10,
                 monthlyTokenLimit = 500_000L
             )
@@ -50,7 +50,7 @@ class PlanQueryServiceTest {
 
             // Then
             assertThat(result.id).isEqualTo(plan.id)
-            assertThat(result.planCode).isEqualTo(PlanCode.PRO)
+            assertThat(result.planCode).isEqualTo(PlanCode.ENTERPRISE)
         }
 
         @Test
@@ -120,7 +120,7 @@ class PlanQueryServiceTest {
                 monthlyTokenLimit = 50_000L
             )
             val plan2 = Plan.create(
-                planCode = PlanCode.PRO,
+                planCode = PlanCode.ENTERPRISE,
                 maxSeats = 10,
                 monthlyTokenLimit = 500_000L
             )
@@ -131,7 +131,7 @@ class PlanQueryServiceTest {
 
             // Then
             assertThat(result).hasSize(2)
-            assertThat(result.map { it.planCode }).containsExactlyInAnyOrder(PlanCode.FREE, PlanCode.PRO)
+            assertThat(result.map { it.planCode }).containsExactlyInAnyOrder(PlanCode.FREE, PlanCode.ENTERPRISE)
         }
 
         @Test

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -8,3 +8,4 @@ spring:
   jpa:
     hibernate:
       ddl-auto: create-drop
+    show-sql: true


### PR DESCRIPTION
 ## Summary
 
  - Plan 도메인 모델 구현 (Plan, PlanId, PlanCode, PlanPolicy)
  - JPA 인프라 레이어 구현 (Soft Delete, Repository Adapter)
  - Command/Query 서비스 분리 (CQS 패턴)
  - REST API 구현 (CRUD /plans)

  ## 주요 구현 사항

  ### 도메인 레이어
  - `PlanPolicy`: 검증 로직 분리 (create/update 시 호출)
  - `reconstitute()`: 검증 생략 - DB 복원 시 장애 전파 방지

  ### 비즈니스 규칙
  | 규칙 | 설명 |
  |-----|-----|
  | FREE/PRO | maxSeats = 1 고정 |
  | ENTERPRISE | maxSeats ≥ 1 |
  | monthlyTokenLimit | ≥ 1 |

  ### API 레이어
  - `@EnumValue` 커스텀 validator: Enum 문자열 검증
  - `MismatchedInputException` 처리: 필수 필드 누락 → INVALID_INPUT

 ## 질문 사항
  ### 1. 검증 레이어 분리

  검증이 세 단계로 나뉠 수 있습니다:

  | 레이어 | 역할 | 현재 구현 |
  |-------|-----|---------|
  | API | 입력값 검증 (형식, 필수값, 타입) | `@Valid` + Bean Validation |
  | Command | 유스케이스 유효성 검증 | ❓ 없음 |
  | Domain | 도메인 불변식 검증 | `PlanPolicy.validate()` |

  현재는 API 레이어에서 입력값 검증, Domain에서 불변식 검증을 하고 있습니다. 

  검증이 세 단계나 필요한지 궁금합니다. Clean Architecture에서는 Use Case(Command/Service)에서도 유효성 검증을 권장하는데, 현재처럼 API와 Domain에서만 검증해도 충분할지 의견 여쭤봐도 될까요?

  ### 2. CustomException vs Kotlin 관용구 (require/check)

  현재 에러 응답을 위해 CustomException을 사용하고 있습니다:

  ```kotlin
  if (maxSeats < 1) {
      throw PlanException(PlanErrorCode.INVALID_MAX_SEATS)  // → 400 Bad Request
  }
```

  Kotlin 관용구인 require/check를 사용하면 코드가 간결해집니다:

```kotlin
 require(maxSeats >= 1) { "maxSeats must be >= 1" }  // → IllegalArgumentException
```

  하지만 IllegalArgumentException을 GlobalExceptionHandler에서 400으로 처리하면, CustomException을 사용하는 의미가 퇴색되는 것 같습니다.

  | 방식                             | 처리                      | 문제점                           |
  |----------------------------------|---------------------------|----------------------------------|
  | CustomException                  | 에러 코드별 세분화된 응답 | 코드가 장황함                    |
  | require + GlobalExceptionHandler | 400으로 일괄 처리         | CustomException 존재 의미 불명확 |

  CustomException을 유지하면서 Kotlin 관용구의 간결함을 활용할 수 있는 방법이 있을지, 아니면 현재처럼 CustomException 방식을 유지하는 게 맞을지 조언 부탁드립니다!



Closes #24