### PR TITLE
feat: License 애그리거트 구현

### DIFF
--- a/src/main/kotlin/com/flab/license/domain/license/License.kt
+++ b/src/main/kotlin/com/flab/license/domain/license/License.kt
@@ -1,5 +1,69 @@
 package com.flab.license.domain.license
 
-class License(
-    val id: String
-)
+import com.flab.license.domain.plan.PlanId
+
+class License private constructor(
+    val id: LicenseId,
+    val planId: PlanId,
+    val owner: Owner,
+    val status: LicenseStatus,
+    val period: Period,
+    val deleted: Boolean = false
+) {
+
+    fun expire(): License {
+        LicensePolicy.validateExpiration(status, deleted)
+        return License(
+            id = this.id,
+            planId = this.planId,
+            owner = this.owner,
+            status = LicenseStatus.EXPIRED,
+            period = this.period,
+            deleted = this.deleted
+        )
+    }
+
+    fun delete(): License {
+        LicensePolicy.validateDeletion(deleted)
+        return License(
+            id = this.id,
+            planId = this.planId,
+            owner = this.owner,
+            status = this.status,
+            period = this.period,
+            deleted = true
+        )
+    }
+
+    companion object {
+        fun create(
+            planId: PlanId,
+            owner: Owner,
+            period: Period
+        ): License {
+            return License(
+                id = LicenseId.generate(),
+                planId = planId,
+                owner = owner,
+                status = LicenseStatus.ACTIVE,
+                period = period
+            )
+        }
+
+        fun reconstitute(
+            id: LicenseId,
+            planId: PlanId,
+            owner: Owner,
+            status: LicenseStatus,
+            period: Period,
+            deleted: Boolean
+        ) = License(
+            id = id,
+            planId = planId,
+            owner = owner,
+            status = status,
+            period = period,
+            deleted = deleted
+        )
+    }
+}

--- a/src/main/kotlin/com/flab/license/domain/license/LicenseId.kt
+++ b/src/main/kotlin/com/flab/license/domain/license/LicenseId.kt
@@ -1,0 +1,11 @@
+package com.flab.license.domain.license
+
+import java.util.*
+
+@JvmInline
+value class LicenseId(val value: UUID) {
+
+    companion object {
+        fun generate(): LicenseId = LicenseId(UUID.randomUUID())
+    }
+}

--- a/src/main/kotlin/com/flab/license/domain/license/LicensePolicy.kt
+++ b/src/main/kotlin/com/flab/license/domain/license/LicensePolicy.kt
@@ -1,0 +1,46 @@
+package com.flab.license.domain.license
+
+import com.flab.license.domain.license.exception.LicenseErrorCode
+import com.flab.license.domain.license.exception.LicenseException
+import java.time.LocalDate
+
+object LicensePolicy {
+
+    fun validateUsable(status: LicenseStatus, deleted: Boolean, period: Period, date: LocalDate) {
+        validateNotDeleted(deleted)
+        validateActive(status)
+        validatePeriod(period, date)
+    }
+
+    fun validateExpiration(status: LicenseStatus, deleted: Boolean) {
+        validateNotDeleted(deleted)
+        if (status.isExpired()) {
+            throw LicenseException(LicenseErrorCode.ALREADY_EXPIRED)
+        }
+    }
+
+    fun validateDeletion(deleted: Boolean) {
+        validateNotDeleted(deleted)
+    }
+
+    private fun validateNotDeleted(deleted: Boolean) {
+        if (deleted) {
+            throw LicenseException(LicenseErrorCode.LICENSE_ALREADY_DELETED)
+        }
+    }
+
+    private fun validateActive(status: LicenseStatus) {
+        if (status.isNotActive()) {
+            throw LicenseException(LicenseErrorCode.LICENSE_NOT_ACTIVE)
+        }
+    }
+
+    private fun validatePeriod(period: Period, date: LocalDate) {
+        if (date.isBefore(period.startDate)) {
+            throw LicenseException(LicenseErrorCode.LICENSE_PERIOD_NOT_STARTED)
+        }
+        if (date.isAfter(period.endDate)) {
+            throw LicenseException(LicenseErrorCode.LICENSE_PERIOD_ENDED)
+        }
+    }
+}

--- a/src/main/kotlin/com/flab/license/domain/license/LicenseRepository.kt
+++ b/src/main/kotlin/com/flab/license/domain/license/LicenseRepository.kt
@@ -1,3 +1,13 @@
 package com.flab.license.domain.license
 
-interface LicenseRepository
+interface LicenseRepository {
+    fun save(license: License): License
+    fun update(license: License): License
+    fun delete(license: License): License
+
+    fun loadById(id: LicenseId): License
+    fun loadByOwner(owner: Owner): List<License>
+
+    // 삭제된 라이선스 포함 조회 (관리자용)
+    fun loadByIdIncludeDeleted(id: LicenseId): License
+}

--- a/src/main/kotlin/com/flab/license/domain/license/LicenseStatus.kt
+++ b/src/main/kotlin/com/flab/license/domain/license/LicenseStatus.kt
@@ -1,0 +1,10 @@
+package com.flab.license.domain.license
+
+enum class LicenseStatus {
+    ACTIVE,
+    EXPIRED;
+
+    fun isActive(): Boolean = this == ACTIVE
+    fun isNotActive(): Boolean = this != ACTIVE
+    fun isExpired(): Boolean = this == EXPIRED
+}

--- a/src/main/kotlin/com/flab/license/domain/license/Owner.kt
+++ b/src/main/kotlin/com/flab/license/domain/license/Owner.kt
@@ -1,0 +1,30 @@
+package com.flab.license.domain.license
+
+import com.flab.license.domain.license.exception.LicenseErrorCode
+import com.flab.license.domain.license.exception.LicenseException
+
+@ConsistentCopyVisibility
+data class Owner private constructor(
+    val type: Type,
+    val id: String
+) {
+    enum class Type {
+        USER,
+        ORGANIZATION
+    }
+
+    companion object {
+        fun user(id: String): Owner = of(Type.USER, id)
+
+        fun organization(id: String): Owner = of(Type.ORGANIZATION, id)
+
+        fun reconstitute(type: Type, id: String) = Owner(type, id)
+
+        private fun of(type: Type, id: String): Owner {
+            if (id.isBlank()) {
+                throw LicenseException(LicenseErrorCode.INVALID_OWNER_ID)
+            }
+            return Owner(type, id)
+        }
+    }
+}

--- a/src/main/kotlin/com/flab/license/domain/license/Period.kt
+++ b/src/main/kotlin/com/flab/license/domain/license/Period.kt
@@ -1,0 +1,23 @@
+package com.flab.license.domain.license
+
+import com.flab.license.domain.license.exception.LicenseErrorCode
+import com.flab.license.domain.license.exception.LicenseException
+import java.time.LocalDate
+
+@ConsistentCopyVisibility
+data class Period private constructor(
+    val startDate: LocalDate,
+    val endDate: LocalDate
+) {
+    companion object {
+        fun of(startDate: LocalDate, endDate: LocalDate): Period {
+            if (endDate.isBefore(startDate)) {
+                throw LicenseException(LicenseErrorCode.INVALID_PERIOD)
+            }
+            return Period(startDate, endDate)
+        }
+
+        fun reconstitute(startDate: LocalDate, endDate: LocalDate) =
+            Period(startDate, endDate)
+    }
+}

--- a/src/main/kotlin/com/flab/license/domain/license/exception/LicenseErrorCode.kt
+++ b/src/main/kotlin/com/flab/license/domain/license/exception/LicenseErrorCode.kt
@@ -7,6 +7,12 @@ enum class LicenseErrorCode(
     override val httpStatus: HttpStatus,
     override val message: String
 ) : ErrorCode {
-
-    LICENSE_NOT_FOUND(HttpStatus.NOT_FOUND, "라이선스를 찾을 수 없습니다")
+    LICENSE_NOT_FOUND(HttpStatus.NOT_FOUND, "라이선스를 찾을 수 없습니다"),
+    INVALID_PERIOD(HttpStatus.BAD_REQUEST, "종료일은 시작일 이후여야 합니다"),
+    LICENSE_ALREADY_DELETED(HttpStatus.BAD_REQUEST, "이미 삭제된 라이선스입니다"),
+    ALREADY_EXPIRED(HttpStatus.BAD_REQUEST, "이미 만료된 라이선스입니다"),
+    INVALID_OWNER_ID(HttpStatus.BAD_REQUEST, "소유자 ID는 빈 값일 수 없습니다"),
+    LICENSE_NOT_ACTIVE(HttpStatus.BAD_REQUEST, "활성 상태의 라이선스가 아닙니다"),
+    LICENSE_PERIOD_NOT_STARTED(HttpStatus.BAD_REQUEST, "라이선스 유효 기간이 시작되지 않았습니다"),
+    LICENSE_PERIOD_ENDED(HttpStatus.BAD_REQUEST, "라이선스 유효 기간이 종료되었습니다")
 }

--- a/src/main/kotlin/com/flab/license/domain/plan/PlanId.kt
+++ b/src/main/kotlin/com/flab/license/domain/plan/PlanId.kt
@@ -1,18 +1,10 @@
 package com.flab.license.domain.plan
 
-import com.flab.license.domain.plan.exception.PlanErrorCode
-import com.flab.license.domain.plan.exception.PlanException
-import java.util.UUID
+import java.util.*
 
 @JvmInline
 value class PlanId(val value: UUID) {
     companion object {
         fun generate(): PlanId = PlanId(UUID.randomUUID())
-
-        fun from(value: String): PlanId = runCatching {
-            PlanId(UUID.fromString(value))
-        }.getOrElse {
-            throw PlanException(PlanErrorCode.INVALID_PLAN_ID)
-        }
     }
 }

--- a/src/main/kotlin/com/flab/license/domain/plan/exception/PlanErrorCode.kt
+++ b/src/main/kotlin/com/flab/license/domain/plan/exception/PlanErrorCode.kt
@@ -9,7 +9,6 @@ enum class PlanErrorCode(
 ) : ErrorCode {
 
     PLAN_NOT_FOUND(HttpStatus.NOT_FOUND, "플랜을 찾을 수 없습니다"),
-    INVALID_PLAN_ID(HttpStatus.BAD_REQUEST, "유효하지 않은 플랜 ID입니다"),
     INVALID_MAX_SEATS(HttpStatus.BAD_REQUEST, "최대 좌석 수는 1 이상이어야 합니다"),
     INVALID_MONTHLY_TOKEN_LIMIT(HttpStatus.BAD_REQUEST, "월별 토큰 한도는 1 이상이어야 합니다"),
     INVALID_MAX_SEATS_FOR_PLAN(HttpStatus.BAD_REQUEST, "FREE/PRO 플랜은 최대 좌석 수가 1이어야 합니다"),

--- a/src/main/kotlin/com/flab/license/infra/persistence/license/jpa/LicenseJpaEntity.kt
+++ b/src/main/kotlin/com/flab/license/infra/persistence/license/jpa/LicenseJpaEntity.kt
@@ -1,6 +1,5 @@
 package com.flab.license.infra.persistence.license.jpa
 
-import com.flab.license.domain.license.License
 import com.flab.license.infra.persistence.common.jpa.BaseTimeEntity
 import jakarta.persistence.*
 
@@ -12,7 +11,5 @@ class LicenseJpaEntity : BaseTimeEntity() {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long = 0
 
-    companion object {
-        fun toDomain(entity: LicenseJpaEntity): License = License(entity.id.toString())
-    }
+
 }

--- a/src/main/kotlin/com/flab/license/infra/persistence/license/jpa/LicenseJpaEntity.kt
+++ b/src/main/kotlin/com/flab/license/infra/persistence/license/jpa/LicenseJpaEntity.kt
@@ -1,15 +1,39 @@
 package com.flab.license.infra.persistence.license.jpa
 
+import com.flab.license.domain.license.LicenseStatus
+import com.flab.license.domain.license.Owner
 import com.flab.license.infra.persistence.common.jpa.BaseTimeEntity
 import jakarta.persistence.*
+import java.time.LocalDate
+import java.util.*
 
 @Entity
 @Table(name = "license")
-class LicenseJpaEntity : BaseTimeEntity() {
-
+class LicenseJpaEntity(
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    val id: Long = 0
+    @Column(columnDefinition = "BINARY(16)")
+    val id: UUID,
 
+    @Column(columnDefinition = "BINARY(16)", nullable = false)
+    val planId: UUID,
 
-}
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    val ownerType: Owner.Type,
+
+    @Column(nullable = false)
+    val ownerId: String,
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    val status: LicenseStatus,
+
+    @Column(nullable = false)
+    val startDate: LocalDate,
+
+    @Column(nullable = false)
+    val endDate: LocalDate,
+
+    @Column(nullable = false)
+    val deleted: Boolean = false
+) : BaseTimeEntity()

--- a/src/main/kotlin/com/flab/license/infra/persistence/license/jpa/LicenseJpaMapper.kt
+++ b/src/main/kotlin/com/flab/license/infra/persistence/license/jpa/LicenseJpaMapper.kt
@@ -1,0 +1,27 @@
+package com.flab.license.infra.persistence.license.jpa
+
+import com.flab.license.domain.license.License
+import com.flab.license.domain.license.LicenseId
+import com.flab.license.domain.license.Owner
+import com.flab.license.domain.license.Period
+import com.flab.license.domain.plan.PlanId
+
+internal fun LicenseJpaEntity.toDomain(): License = License.reconstitute(
+    id = LicenseId(id),
+    planId = PlanId(planId),
+    owner = Owner.reconstitute(ownerType, ownerId),
+    status = status,
+    period = Period.reconstitute(startDate, endDate),
+    deleted = deleted
+)
+
+internal fun License.toEntity(): LicenseJpaEntity = LicenseJpaEntity(
+    id = id.value,
+    planId = planId.value,
+    ownerType = owner.type,
+    ownerId = owner.id,
+    status = status,
+    startDate = period.startDate,
+    endDate = period.endDate,
+    deleted = deleted
+)

--- a/src/main/kotlin/com/flab/license/infra/persistence/license/jpa/LicenseRepositoryJpaAdapter.kt
+++ b/src/main/kotlin/com/flab/license/infra/persistence/license/jpa/LicenseRepositoryJpaAdapter.kt
@@ -1,9 +1,44 @@
 package com.flab.license.infra.persistence.license.jpa
 
+import com.flab.license.common.exception.CommonErrorCode
+import com.flab.license.common.exception.CustomException
+import com.flab.license.domain.license.License
+import com.flab.license.domain.license.LicenseId
 import com.flab.license.domain.license.LicenseRepository
+import com.flab.license.domain.license.Owner
+import com.flab.license.domain.license.exception.LicenseErrorCode
+import com.flab.license.domain.license.exception.LicenseException
 import org.springframework.stereotype.Repository
 
 @Repository
 class LicenseRepositoryJpaAdapter(
     private val springDataJpaRepository: LicenseSpringDataJpaRepository
-) : LicenseRepository
+) : LicenseRepository {
+
+    override fun save(license: License): License {
+        val entity = license.toEntity()
+        val saved = springDataJpaRepository.save(entity)
+        return saved.toDomain()
+    }
+
+    override fun update(license: License): License = save(license)
+
+    override fun delete(license: License): License = save(license)
+
+    override fun loadById(id: LicenseId): License {
+        return findById(id) ?: throw LicenseException(LicenseErrorCode.LICENSE_NOT_FOUND)
+    }
+
+    override fun loadByOwner(owner: Owner): List<License> {
+        return springDataJpaRepository.findByOwnerTypeAndOwnerIdAndDeletedFalse(owner.type, owner.id)
+            .map { it.toDomain() }
+    }
+
+    private fun findById(id: LicenseId): License? {
+        return springDataJpaRepository.findByIdAndDeletedFalse(id.value)?.toDomain()
+    }
+
+    override fun loadByIdIncludeDeleted(id: LicenseId): License {
+        throw CustomException(CommonErrorCode.NOT_IMPLEMENTED)
+    }
+}

--- a/src/main/kotlin/com/flab/license/infra/persistence/license/jpa/LicenseSpringDataJpaRepository.kt
+++ b/src/main/kotlin/com/flab/license/infra/persistence/license/jpa/LicenseSpringDataJpaRepository.kt
@@ -1,5 +1,10 @@
 package com.flab.license.infra.persistence.license.jpa
 
+import com.flab.license.domain.license.Owner
 import org.springframework.data.jpa.repository.JpaRepository
+import java.util.UUID
 
-interface LicenseSpringDataJpaRepository : JpaRepository<LicenseJpaEntity, Long>
+interface LicenseSpringDataJpaRepository : JpaRepository<LicenseJpaEntity, UUID> {
+    fun findByIdAndDeletedFalse(id: UUID): LicenseJpaEntity?
+    fun findByOwnerTypeAndOwnerIdAndDeletedFalse(ownerType: Owner.Type, ownerId: String): List<LicenseJpaEntity>
+}

--- a/src/test/kotlin/com/flab/license/domain/license/LicenseIdTest.kt
+++ b/src/test/kotlin/com/flab/license/domain/license/LicenseIdTest.kt
@@ -1,0 +1,67 @@
+package com.flab.license.domain.license
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.util.*
+
+class LicenseIdTest {
+
+    @Nested
+    @DisplayName("generate")
+    inner class Generate {
+
+        @Test
+        @DisplayName("UUID를 생성할 수 있다")
+        fun `generate creates valid UUID`() {
+            // When
+            val licenseId = LicenseId.generate()
+
+            // Then
+            assertThat(licenseId.value).isNotNull()
+            assertThat(licenseId.value).isInstanceOf(UUID::class.java)
+        }
+
+        @Test
+        @DisplayName("생성할 때마다 다른 UUID가 생성된다")
+        fun `generate creates unique UUIDs`() {
+            // When
+            val licenseId1 = LicenseId.generate()
+            val licenseId2 = LicenseId.generate()
+
+            // Then
+            assertThat(licenseId1).isNotEqualTo(licenseId2)
+        }
+    }
+
+    @Nested
+    @DisplayName("equality")
+    inner class Equality {
+
+        @Test
+        @DisplayName("같은 UUID를 가진 LicenseId는 동등하다")
+        fun `LicenseIds with same UUID are equal`() {
+            // Given
+            val uuid = UUID.randomUUID()
+
+            // When
+            val licenseId1 = LicenseId(uuid)
+            val licenseId2 = LicenseId(uuid)
+
+            // Then
+            assertThat(licenseId1).isEqualTo(licenseId2)
+        }
+
+        @Test
+        @DisplayName("다른 UUID를 가진 LicenseId는 동등하지 않다")
+        fun `LicenseIds with different UUIDs are not equal`() {
+            // When
+            val licenseId1 = LicenseId(UUID.randomUUID())
+            val licenseId2 = LicenseId(UUID.randomUUID())
+
+            // Then
+            assertThat(licenseId1).isNotEqualTo(licenseId2)
+        }
+    }
+}

--- a/src/test/kotlin/com/flab/license/domain/license/LicensePolicyTest.kt
+++ b/src/test/kotlin/com/flab/license/domain/license/LicensePolicyTest.kt
@@ -1,0 +1,209 @@
+package com.flab.license.domain.license
+
+import com.flab.license.domain.license.exception.LicenseErrorCode
+import com.flab.license.domain.license.exception.LicenseException
+import org.assertj.core.api.Assertions.assertThatCode
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+
+class LicensePolicyTest {
+
+    private val defaultPeriod = Period.of(
+        LocalDate.of(2025, 1, 1),
+        LocalDate.of(2025, 12, 31)
+    )
+
+    @Nested
+    @DisplayName("validateUsable")
+    inner class ValidateUsable {
+
+        @Test
+        @DisplayName("ACTIVE 상태이고 삭제되지 않았으며 유효 기간 내이면 검증을 통과한다")
+        fun `valid license passes validation`() {
+            // Given
+            val dateInPeriod = LocalDate.of(2025, 6, 15)
+
+            // When & Then
+            assertThatCode {
+                LicensePolicy.validateUsable(
+                    status = LicenseStatus.ACTIVE,
+                    deleted = false,
+                    period = defaultPeriod,
+                    date = dateInPeriod
+                )
+            }.doesNotThrowAnyException()
+        }
+
+        @Test
+        @DisplayName("삭제된 라이선스는 LICENSE_ALREADY_DELETED 예외가 발생한다")
+        fun `throw exception when license is deleted`() {
+            assertThatThrownBy {
+                LicensePolicy.validateUsable(
+                    status = LicenseStatus.ACTIVE,
+                    deleted = true,
+                    period = defaultPeriod,
+                    date = LocalDate.of(2025, 6, 15)
+                )
+            }.isInstanceOf(LicenseException::class.java)
+                .extracting("errorCode")
+                .isEqualTo(LicenseErrorCode.LICENSE_ALREADY_DELETED)
+        }
+
+        @Test
+        @DisplayName("ACTIVE 상태가 아니면 LICENSE_NOT_ACTIVE 예외가 발생한다")
+        fun `throw exception when license is not active`() {
+            assertThatThrownBy {
+                LicensePolicy.validateUsable(
+                    status = LicenseStatus.EXPIRED,
+                    deleted = false,
+                    period = defaultPeriod,
+                    date = LocalDate.of(2025, 6, 15)
+                )
+            }.isInstanceOf(LicenseException::class.java)
+                .extracting("errorCode")
+                .isEqualTo(LicenseErrorCode.LICENSE_NOT_ACTIVE)
+        }
+
+        @Test
+        @DisplayName("유효 기간 시작일 이전이면 LICENSE_PERIOD_NOT_STARTED 예외가 발생한다")
+        fun `throw exception when date is before period start`() {
+            assertThatThrownBy {
+                LicensePolicy.validateUsable(
+                    status = LicenseStatus.ACTIVE,
+                    deleted = false,
+                    period = defaultPeriod,
+                    date = LocalDate.of(2024, 12, 31)
+                )
+            }.isInstanceOf(LicenseException::class.java)
+                .extracting("errorCode")
+                .isEqualTo(LicenseErrorCode.LICENSE_PERIOD_NOT_STARTED)
+        }
+
+        @Test
+        @DisplayName("유효 기간 종료일 이후면 LICENSE_PERIOD_ENDED 예외가 발생한다")
+        fun `throw exception when date is after period end`() {
+            assertThatThrownBy {
+                LicensePolicy.validateUsable(
+                    status = LicenseStatus.ACTIVE,
+                    deleted = false,
+                    period = defaultPeriod,
+                    date = LocalDate.of(2026, 1, 1)
+                )
+            }.isInstanceOf(LicenseException::class.java)
+                .extracting("errorCode")
+                .isEqualTo(LicenseErrorCode.LICENSE_PERIOD_ENDED)
+        }
+
+        @Test
+        @DisplayName("시작일에는 사용 가능하다")
+        fun `license is usable on start date`() {
+            assertThatCode {
+                LicensePolicy.validateUsable(
+                    status = LicenseStatus.ACTIVE,
+                    deleted = false,
+                    period = defaultPeriod,
+                    date = LocalDate.of(2025, 1, 1)
+                )
+            }.doesNotThrowAnyException()
+        }
+
+        @Test
+        @DisplayName("종료일에는 사용 가능하다")
+        fun `license is usable on end date`() {
+            assertThatCode {
+                LicensePolicy.validateUsable(
+                    status = LicenseStatus.ACTIVE,
+                    deleted = false,
+                    period = defaultPeriod,
+                    date = LocalDate.of(2025, 12, 31)
+                )
+            }.doesNotThrowAnyException()
+        }
+
+        @Test
+        @DisplayName("삭제 검증이 가장 먼저 수행된다")
+        fun `deleted validation has highest priority`() {
+            // 삭제 + 비활성 + 기간 외 → 삭제 예외가 먼저
+            assertThatThrownBy {
+                LicensePolicy.validateUsable(
+                    status = LicenseStatus.EXPIRED,
+                    deleted = true,
+                    period = defaultPeriod,
+                    date = LocalDate.of(2026, 1, 1)
+                )
+            }.isInstanceOf(LicenseException::class.java)
+                .extracting("errorCode")
+                .isEqualTo(LicenseErrorCode.LICENSE_ALREADY_DELETED)
+        }
+    }
+
+    @Nested
+    @DisplayName("validateExpiration")
+    inner class ValidateExpiration {
+
+        @Test
+        @DisplayName("ACTIVE 상태이고 삭제되지 않은 라이선스는 검증을 통과한다")
+        fun `active and not deleted license passes validation`() {
+            assertThatCode {
+                LicensePolicy.validateExpiration(LicenseStatus.ACTIVE, deleted = false)
+            }.doesNotThrowAnyException()
+        }
+
+        @Test
+        @DisplayName("이미 만료된 라이선스는 ALREADY_EXPIRED 예외가 발생한다")
+        fun `throw exception when license is already expired`() {
+            assertThatThrownBy {
+                LicensePolicy.validateExpiration(LicenseStatus.EXPIRED, deleted = false)
+            }.isInstanceOf(LicenseException::class.java)
+                .extracting("errorCode")
+                .isEqualTo(LicenseErrorCode.ALREADY_EXPIRED)
+        }
+
+        @Test
+        @DisplayName("삭제된 라이선스는 LICENSE_ALREADY_DELETED 예외가 발생한다")
+        fun `throw exception when license is deleted`() {
+            assertThatThrownBy {
+                LicensePolicy.validateExpiration(LicenseStatus.ACTIVE, deleted = true)
+            }.isInstanceOf(LicenseException::class.java)
+                .extracting("errorCode")
+                .isEqualTo(LicenseErrorCode.LICENSE_ALREADY_DELETED)
+        }
+
+        @Test
+        @DisplayName("삭제된 상태가 만료 상태보다 먼저 검증된다")
+        fun `deleted validation has priority over expired validation`() {
+            // 삭제되고 만료된 라이선스 → 삭제 예외가 먼저 발생
+            assertThatThrownBy {
+                LicensePolicy.validateExpiration(LicenseStatus.EXPIRED, deleted = true)
+            }.isInstanceOf(LicenseException::class.java)
+                .extracting("errorCode")
+                .isEqualTo(LicenseErrorCode.LICENSE_ALREADY_DELETED)
+        }
+    }
+
+    @Nested
+    @DisplayName("validateDeletion")
+    inner class ValidateDeletion {
+
+        @Test
+        @DisplayName("삭제되지 않은 라이선스는 검증을 통과한다")
+        fun `not deleted license passes validation`() {
+            assertThatCode {
+                LicensePolicy.validateDeletion(deleted = false)
+            }.doesNotThrowAnyException()
+        }
+
+        @Test
+        @DisplayName("이미 삭제된 라이선스는 LICENSE_ALREADY_DELETED 예외가 발생한다")
+        fun `throw exception when license is already deleted`() {
+            assertThatThrownBy {
+                LicensePolicy.validateDeletion(deleted = true)
+            }.isInstanceOf(LicenseException::class.java)
+                .extracting("errorCode")
+                .isEqualTo(LicenseErrorCode.LICENSE_ALREADY_DELETED)
+        }
+    }
+}

--- a/src/test/kotlin/com/flab/license/domain/license/LicenseTest.kt
+++ b/src/test/kotlin/com/flab/license/domain/license/LicenseTest.kt
@@ -1,0 +1,388 @@
+package com.flab.license.domain.license
+
+import com.flab.license.domain.license.exception.LicenseErrorCode
+import com.flab.license.domain.license.exception.LicenseException
+import com.flab.license.domain.plan.PlanId
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+
+class LicenseTest {
+
+    private val defaultPlanId = PlanId.generate()
+    private val defaultOwner = Owner.user("user-123")
+    private val defaultPeriod = Period.of(
+        LocalDate.of(2025, 1, 1),
+        LocalDate.of(2025, 12, 31)
+    )
+
+    @Nested
+    @DisplayName("create")
+    inner class Create {
+
+        @Test
+        @DisplayName("라이선스를 생성할 수 있다")
+        fun `create license successfully`() {
+            // When
+            val license = License.create(
+                planId = defaultPlanId,
+                owner = defaultOwner,
+                period = defaultPeriod
+            )
+
+            // Then
+            assertThat(license.id).isNotNull()
+            assertThat(license.planId).isEqualTo(defaultPlanId)
+            assertThat(license.owner).isEqualTo(defaultOwner)
+            assertThat(license.status).isEqualTo(LicenseStatus.ACTIVE)
+            assertThat(license.period).isEqualTo(defaultPeriod)
+            assertThat(license.deleted).isFalse()
+        }
+
+        @Test
+        @DisplayName("USER 타입 Owner로 라이선스를 생성할 수 있다")
+        fun `create license with USER owner`() {
+            // Given
+            val userOwner = Owner.user("user-456")
+
+            // When
+            val license = License.create(
+                planId = defaultPlanId,
+                owner = userOwner,
+                period = defaultPeriod
+            )
+
+            // Then
+            assertThat(license.owner.type).isEqualTo(Owner.Type.USER)
+        }
+
+        @Test
+        @DisplayName("ORGANIZATION 타입 Owner로 라이선스를 생성할 수 있다")
+        fun `create license with ORGANIZATION owner`() {
+            // Given
+            val orgOwner = Owner.organization("org-123")
+
+            // When
+            val license = License.create(
+                planId = defaultPlanId,
+                owner = orgOwner,
+                period = defaultPeriod
+            )
+
+            // Then
+            assertThat(license.owner.type).isEqualTo(Owner.Type.ORGANIZATION)
+        }
+
+        @Test
+        @DisplayName("생성된 라이선스는 ACTIVE 상태이다")
+        fun `created license has ACTIVE status`() {
+            // When
+            val license = License.create(
+                planId = defaultPlanId,
+                owner = defaultOwner,
+                period = defaultPeriod
+            )
+
+            // Then
+            assertThat(license.status).isEqualTo(LicenseStatus.ACTIVE)
+            assertThat(license.status.isActive()).isTrue()
+            assertThat(license.status.isExpired()).isFalse()
+        }
+    }
+
+    @Nested
+    @DisplayName("expire")
+    inner class Expire {
+
+        @Test
+        @DisplayName("ACTIVE 라이선스를 만료시킬 수 있다")
+        fun `expire active license successfully`() {
+            // Given
+            val license = License.create(
+                planId = defaultPlanId,
+                owner = defaultOwner,
+                period = defaultPeriod
+            )
+
+            // When
+            val expiredLicense = license.expire()
+
+            // Then
+            assertThat(expiredLicense.id).isEqualTo(license.id)
+            assertThat(expiredLicense.planId).isEqualTo(license.planId)
+            assertThat(expiredLicense.owner).isEqualTo(license.owner)
+            assertThat(expiredLicense.status).isEqualTo(LicenseStatus.EXPIRED)
+            assertThat(expiredLicense.period).isEqualTo(license.period)
+            assertThat(expiredLicense.deleted).isEqualTo(license.deleted)
+        }
+
+        @Test
+        @DisplayName("이미 만료된 라이선스를 만료시키면 예외가 발생한다")
+        fun `throw exception when expire already expired license`() {
+            // Given
+            val license = License.create(
+                planId = defaultPlanId,
+                owner = defaultOwner,
+                period = defaultPeriod
+            )
+            val expiredLicense = license.expire()
+
+            // When & Then
+            assertThatThrownBy { expiredLicense.expire() }
+                .isInstanceOf(LicenseException::class.java)
+                .extracting("errorCode")
+                .isEqualTo(LicenseErrorCode.ALREADY_EXPIRED)
+        }
+
+        @Test
+        @DisplayName("삭제된 라이선스를 만료시키면 예외가 발생한다")
+        fun `throw exception when expire deleted license`() {
+            // Given
+            val license = License.create(
+                planId = defaultPlanId,
+                owner = defaultOwner,
+                period = defaultPeriod
+            )
+            val deletedLicense = license.delete()
+
+            // When & Then
+            assertThatThrownBy { deletedLicense.expire() }
+                .isInstanceOf(LicenseException::class.java)
+                .extracting("errorCode")
+                .isEqualTo(LicenseErrorCode.LICENSE_ALREADY_DELETED)
+        }
+    }
+
+    @Nested
+    @DisplayName("delete")
+    inner class Delete {
+
+        @Test
+        @DisplayName("라이선스를 삭제하면 deleted가 true가 된다")
+        fun `delete license sets deleted to true`() {
+            // Given
+            val license = License.create(
+                planId = defaultPlanId,
+                owner = defaultOwner,
+                period = defaultPeriod
+            )
+
+            // When
+            val deletedLicense = license.delete()
+
+            // Then
+            assertThat(deletedLicense.deleted).isTrue()
+            assertThat(deletedLicense.id).isEqualTo(license.id)
+            assertThat(deletedLicense.planId).isEqualTo(license.planId)
+            assertThat(deletedLicense.owner).isEqualTo(license.owner)
+            assertThat(deletedLicense.status).isEqualTo(license.status)
+            assertThat(deletedLicense.period).isEqualTo(license.period)
+        }
+
+        @Test
+        @DisplayName("이미 삭제된 라이선스를 다시 삭제하면 예외가 발생한다")
+        fun `throw exception when delete already deleted license`() {
+            // Given
+            val license = License.create(
+                planId = defaultPlanId,
+                owner = defaultOwner,
+                period = defaultPeriod
+            )
+            val deletedLicense = license.delete()
+
+            // When & Then
+            assertThatThrownBy { deletedLicense.delete() }
+                .isInstanceOf(LicenseException::class.java)
+                .extracting("errorCode")
+                .isEqualTo(LicenseErrorCode.LICENSE_ALREADY_DELETED)
+        }
+
+        @Test
+        @DisplayName("만료된 라이선스도 삭제할 수 있다")
+        fun `delete expired license successfully`() {
+            // Given
+            val license = License.create(
+                planId = defaultPlanId,
+                owner = defaultOwner,
+                period = defaultPeriod
+            )
+            val expiredLicense = license.expire()
+
+            // When
+            val deletedLicense = expiredLicense.delete()
+
+            // Then
+            assertThat(deletedLicense.deleted).isTrue()
+            assertThat(deletedLicense.status).isEqualTo(LicenseStatus.EXPIRED)
+        }
+    }
+
+    @Nested
+    @DisplayName("reconstitute")
+    inner class Reconstitute {
+
+        @Test
+        @DisplayName("저장된 라이선스를 복원할 수 있다")
+        fun `reconstitute license successfully`() {
+            // Given
+            val id = LicenseId.generate()
+            val planId = PlanId.generate()
+            val owner = Owner.user("user-789")
+            val status = LicenseStatus.ACTIVE
+            val period = Period.reconstitute(
+                LocalDate.of(2025, 1, 1),
+                LocalDate.of(2025, 12, 31)
+            )
+            val deleted = false
+
+            // When
+            val license = License.reconstitute(
+                id = id,
+                planId = planId,
+                owner = owner,
+                status = status,
+                period = period,
+                deleted = deleted
+            )
+
+            // Then
+            assertThat(license.id).isEqualTo(id)
+            assertThat(license.planId).isEqualTo(planId)
+            assertThat(license.owner).isEqualTo(owner)
+            assertThat(license.status).isEqualTo(status)
+            assertThat(license.period).isEqualTo(period)
+            assertThat(license.deleted).isEqualTo(deleted)
+        }
+
+        @Test
+        @DisplayName("삭제된 라이선스도 복원할 수 있다")
+        fun `reconstitute deleted license`() {
+            // Given
+            val id = LicenseId.generate()
+
+            // When
+            val license = License.reconstitute(
+                id = id,
+                planId = defaultPlanId,
+                owner = defaultOwner,
+                status = LicenseStatus.EXPIRED,
+                period = defaultPeriod,
+                deleted = true
+            )
+
+            // Then
+            assertThat(license.deleted).isTrue()
+            assertThat(license.status).isEqualTo(LicenseStatus.EXPIRED)
+        }
+
+        @Test
+        @DisplayName("만료된 라이선스도 복원할 수 있다")
+        fun `reconstitute expired license`() {
+            // Given
+            val id = LicenseId.generate()
+
+            // When
+            val license = License.reconstitute(
+                id = id,
+                planId = defaultPlanId,
+                owner = defaultOwner,
+                status = LicenseStatus.EXPIRED,
+                period = defaultPeriod,
+                deleted = false
+            )
+
+            // Then
+            assertThat(license.status).isEqualTo(LicenseStatus.EXPIRED)
+            assertThat(license.status.isExpired()).isTrue()
+        }
+    }
+
+    @Nested
+    @DisplayName("상태 전이 시나리오")
+    inner class StateTransition {
+
+        @Test
+        @DisplayName("create → expire → delete 전체 생명주기")
+        fun `full lifecycle - create, expire, delete`() {
+            // Given
+            val license = License.create(
+                planId = defaultPlanId,
+                owner = defaultOwner,
+                period = defaultPeriod
+            )
+
+            // When
+            val expiredLicense = license.expire()
+            val deletedLicense = expiredLicense.delete()
+
+            // Then
+            assertThat(deletedLicense.id).isEqualTo(license.id)
+            assertThat(deletedLicense.status).isEqualTo(LicenseStatus.EXPIRED)
+            assertThat(deletedLicense.deleted).isTrue()
+        }
+
+        @Test
+        @DisplayName("create → delete (만료 건너뛰기)")
+        fun `create and delete without expire`() {
+            // Given
+            val license = License.create(
+                planId = defaultPlanId,
+                owner = defaultOwner,
+                period = defaultPeriod
+            )
+
+            // When
+            val deletedLicense = license.delete()
+
+            // Then
+            assertThat(deletedLicense.status).isEqualTo(LicenseStatus.ACTIVE)
+            assertThat(deletedLicense.deleted).isTrue()
+        }
+
+        @Test
+        @DisplayName("삭제된 라이선스는 만료시킬 수 없다 (삭제 우선)")
+        fun `deleted license cannot be expired`() {
+            // Given
+            val license = License.create(
+                planId = defaultPlanId,
+                owner = defaultOwner,
+                period = defaultPeriod
+            )
+            val deletedLicense = license.delete()
+
+            // When & Then
+            assertThatThrownBy { deletedLicense.expire() }
+                .isInstanceOf(LicenseException::class.java)
+                .extracting("errorCode")
+                .isEqualTo(LicenseErrorCode.LICENSE_ALREADY_DELETED)
+        }
+
+        @Test
+        @DisplayName("상태 전이 후에도 불변 속성은 유지된다")
+        fun `immutable properties preserved after state transitions`() {
+            // Given
+            val license = License.create(
+                planId = defaultPlanId,
+                owner = defaultOwner,
+                period = defaultPeriod
+            )
+            val originalId = license.id
+            val originalPlanId = license.planId
+            val originalOwner = license.owner
+            val originalPeriod = license.period
+
+            // When
+            val expiredLicense = license.expire()
+            val deletedLicense = expiredLicense.delete()
+
+            // Then
+            assertThat(deletedLicense.id).isEqualTo(originalId)
+            assertThat(deletedLicense.planId).isEqualTo(originalPlanId)
+            assertThat(deletedLicense.owner).isEqualTo(originalOwner)
+            assertThat(deletedLicense.period).isEqualTo(originalPeriod)
+        }
+    }
+}

--- a/src/test/kotlin/com/flab/license/domain/license/OwnerTest.kt
+++ b/src/test/kotlin/com/flab/license/domain/license/OwnerTest.kt
@@ -1,0 +1,96 @@
+package com.flab.license.domain.license
+
+import com.flab.license.domain.license.exception.LicenseErrorCode
+import com.flab.license.domain.license.exception.LicenseException
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatCode
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+
+class OwnerTest {
+
+    @Nested
+    @DisplayName("user")
+    inner class User {
+
+        @Test
+        @DisplayName("USER 타입 Owner를 생성할 수 있다")
+        fun `create USER owner successfully`() {
+            // When
+            val owner = Owner.user("user-123")
+
+            // Then
+            assertThat(owner.type).isEqualTo(Owner.Type.USER)
+            assertThat(owner.id).isEqualTo("user-123")
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = ["", " ", "  "])
+        @DisplayName("id가 빈 값이면 예외가 발생한다")
+        fun `throw exception when id is blank`(blankId: String) {
+            // When & Then
+            assertThatThrownBy {
+                Owner.user(blankId)
+            }.isInstanceOf(LicenseException::class.java)
+                .extracting("errorCode")
+                .isEqualTo(LicenseErrorCode.INVALID_OWNER_ID)
+        }
+    }
+
+    @Nested
+    @DisplayName("organization")
+    inner class Organization {
+
+        @Test
+        @DisplayName("ORGANIZATION 타입 Owner를 생성할 수 있다")
+        fun `create ORGANIZATION owner successfully`() {
+            // When
+            val owner = Owner.organization("org-456")
+
+            // Then
+            assertThat(owner.type).isEqualTo(Owner.Type.ORGANIZATION)
+            assertThat(owner.id).isEqualTo("org-456")
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = ["", " ", "  "])
+        @DisplayName("id가 빈 값이면 예외가 발생한다")
+        fun `throw exception when id is blank`(blankId: String) {
+            // When & Then
+            assertThatThrownBy {
+                Owner.organization(blankId)
+            }.isInstanceOf(LicenseException::class.java)
+                .extracting("errorCode")
+                .isEqualTo(LicenseErrorCode.INVALID_OWNER_ID)
+        }
+    }
+
+    @Nested
+    @DisplayName("reconstitute")
+    inner class Reconstitute {
+
+        @Test
+        @DisplayName("저장된 Owner를 복원할 수 있다")
+        fun `reconstitute owner successfully`() {
+            // When
+            val owner = Owner.reconstitute(Owner.Type.USER, "user-123")
+
+            // Then
+            assertThat(owner.type).isEqualTo(Owner.Type.USER)
+            assertThat(owner.id).isEqualTo("user-123")
+        }
+
+        @Test
+        @DisplayName("reconstitute는 검증을 건너뛴다 - 빈 id도 복원 가능")
+        fun `reconstitute skips validation for blank id`() {
+            // When & Then
+            assertThatCode {
+                Owner.reconstitute(Owner.Type.USER, "")
+            }.doesNotThrowAnyException()
+        }
+    }
+}

--- a/src/test/kotlin/com/flab/license/domain/license/PeriodTest.kt
+++ b/src/test/kotlin/com/flab/license/domain/license/PeriodTest.kt
@@ -1,0 +1,134 @@
+package com.flab.license.domain.license
+
+import com.flab.license.domain.license.exception.LicenseErrorCode
+import com.flab.license.domain.license.exception.LicenseException
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatCode
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+
+class PeriodTest {
+
+    @Nested
+    @DisplayName("of")
+    inner class Of {
+
+        @Test
+        @DisplayName("유효한 기간을 생성할 수 있다")
+        fun `create valid period`() {
+            // Given
+            val startDate = LocalDate.of(2025, 1, 1)
+            val endDate = LocalDate.of(2025, 12, 31)
+
+            // When
+            val period = Period.of(startDate, endDate)
+
+            // Then
+            assertThat(period.startDate).isEqualTo(startDate)
+            assertThat(period.endDate).isEqualTo(endDate)
+        }
+
+        @Test
+        @DisplayName("시작일과 종료일이 같아도 생성할 수 있다")
+        fun `create period with same start and end date`() {
+            // Given
+            val date = LocalDate.of(2025, 6, 15)
+
+            // When
+            val period = Period.of(date, date)
+
+            // Then
+            assertThat(period.startDate).isEqualTo(date)
+            assertThat(period.endDate).isEqualTo(date)
+        }
+
+        @Test
+        @DisplayName("종료일이 시작일보다 이전이면 예외가 발생한다")
+        fun `throw exception when endDate is before startDate`() {
+            // Given
+            val startDate = LocalDate.of(2025, 12, 31)
+            val endDate = LocalDate.of(2025, 1, 1)
+
+            // When & Then
+            assertThatThrownBy { Period.of(startDate, endDate) }
+                .isInstanceOf(LicenseException::class.java)
+                .extracting("errorCode")
+                .isEqualTo(LicenseErrorCode.INVALID_PERIOD)
+        }
+    }
+
+    @Nested
+    @DisplayName("reconstitute")
+    inner class Reconstitute {
+
+        @Test
+        @DisplayName("저장된 기간을 검증 없이 복원할 수 있다")
+        fun `reconstitute period without validation`() {
+            // Given
+            val startDate = LocalDate.of(2025, 1, 1)
+            val endDate = LocalDate.of(2025, 12, 31)
+
+            // When
+            val period = Period.reconstitute(startDate, endDate)
+
+            // Then
+            assertThat(period.startDate).isEqualTo(startDate)
+            assertThat(period.endDate).isEqualTo(endDate)
+        }
+
+        @Test
+        @DisplayName("복원 시 검증을 수행하지 않는다 - 잘못된 데이터도 복원 가능")
+        fun `reconstitute skips validation for invalid data`() {
+            // Given - 잘못된 데이터 (endDate < startDate)
+            val startDate = LocalDate.of(2025, 12, 31)
+            val endDate = LocalDate.of(2025, 1, 1)
+
+            // When - 복원은 성공
+            assertThatCode {
+                Period.reconstitute(startDate, endDate)
+            }.doesNotThrowAnyException()
+        }
+    }
+
+    @Nested
+    @DisplayName("equals")
+    inner class Equals {
+
+        @Test
+        @DisplayName("같은 값을 가진 Period는 동일하다")
+        fun `periods with same values are equal`() {
+            // Given
+            val period1 = Period.of(
+                LocalDate.of(2025, 1, 1),
+                LocalDate.of(2025, 12, 31)
+            )
+            val period2 = Period.of(
+                LocalDate.of(2025, 1, 1),
+                LocalDate.of(2025, 12, 31)
+            )
+
+            // When & Then
+            assertThat(period1).isEqualTo(period2)
+        }
+
+        @Test
+        @DisplayName("다른 값을 가진 Period는 동일하지 않다")
+        fun `periods with different values are not equal`() {
+            // Given
+            val period1 = Period.of(
+                LocalDate.of(2025, 1, 1),
+                LocalDate.of(2025, 12, 31)
+            )
+            val period2 = Period.of(
+                LocalDate.of(2025, 1, 1),
+                LocalDate.of(2026, 12, 31)
+            )
+
+            // When & Then
+            assertThat(period1).isNotEqualTo(period2)
+        }
+    }
+}

--- a/src/test/kotlin/com/flab/license/domain/plan/PlanIdTest.kt
+++ b/src/test/kotlin/com/flab/license/domain/plan/PlanIdTest.kt
@@ -1,9 +1,6 @@
 package com.flab.license.domain.plan
 
-import com.flab.license.domain.plan.exception.PlanErrorCode
-import com.flab.license.domain.plan.exception.PlanException
 import org.assertj.core.api.Assertions.assertThat
-import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -35,63 +32,6 @@ class PlanIdTest {
 
             // Then
             assertThat(planId1).isNotEqualTo(planId2)
-        }
-    }
-
-    @Nested
-    @DisplayName("from")
-    inner class From {
-
-        @Test
-        @DisplayName("유효한 UUID 문자열로 PlanId를 생성할 수 있다")
-        fun `from creates PlanId from valid UUID string`() {
-            // Given
-            val uuidString = "550e8400-e29b-41d4-a716-446655440000"
-
-            // When
-            val planId = PlanId.from(uuidString)
-
-            // Then
-            assertThat(planId.value.toString()).isEqualTo(uuidString)
-        }
-
-        @Test
-        @DisplayName("잘못된 UUID 문자열이면 예외가 발생한다")
-        fun `from throws exception for invalid UUID string`() {
-            // Given
-            val invalidUuidString = "invalid-uuid"
-
-            // When & Then
-            assertThatThrownBy {
-                PlanId.from(invalidUuidString)
-            }.isInstanceOf(PlanException::class.java)
-                .extracting("errorCode")
-                .isEqualTo(PlanErrorCode.INVALID_PLAN_ID)
-        }
-
-        @Test
-        @DisplayName("빈 문자열이면 예외가 발생한다")
-        fun `from throws exception for empty string`() {
-            // When & Then
-            assertThatThrownBy {
-                PlanId.from("")
-            }.isInstanceOf(PlanException::class.java)
-                .extracting("errorCode")
-                .isEqualTo(PlanErrorCode.INVALID_PLAN_ID)
-        }
-
-        @Test
-        @DisplayName("UUID 형식이 아닌 문자열이면 예외가 발생한다")
-        fun `from throws exception for non-UUID format`() {
-            // Given
-            val nonUuidString = "12345"
-
-            // When & Then
-            assertThatThrownBy {
-                PlanId.from(nonUuidString)
-            }.isInstanceOf(PlanException::class.java)
-                .extracting("errorCode")
-                .isEqualTo(PlanErrorCode.INVALID_PLAN_ID)
         }
     }
 

--- a/src/test/kotlin/com/flab/license/infra/persistence/license/jpa/LicenseRepositoryJpaAdapterTest.kt
+++ b/src/test/kotlin/com/flab/license/infra/persistence/license/jpa/LicenseRepositoryJpaAdapterTest.kt
@@ -1,0 +1,298 @@
+package com.flab.license.infra.persistence.license.jpa
+
+import com.flab.license.common.config.JpaConfig
+import com.flab.license.common.exception.CommonErrorCode
+import com.flab.license.common.exception.CustomException
+import com.flab.license.domain.license.*
+import com.flab.license.domain.license.exception.LicenseErrorCode
+import com.flab.license.domain.license.exception.LicenseException
+import com.flab.license.domain.plan.PlanId
+import jakarta.persistence.EntityManager
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import org.springframework.context.annotation.Import
+import java.time.LocalDate
+
+@DataJpaTest
+@Import(LicenseRepositoryJpaAdapter::class, JpaConfig::class)
+class LicenseRepositoryJpaAdapterTest {
+
+    @Autowired
+    private lateinit var licenseRepository: LicenseRepository
+
+    @Autowired
+    private lateinit var springDataJpaRepository: LicenseSpringDataJpaRepository
+
+    @Autowired
+    private lateinit var entityManager: EntityManager
+
+    private val defaultPlanId = PlanId.generate()
+    private val defaultOwner = Owner.user("user-123")
+    private val defaultPeriod = Period.of(
+        LocalDate.of(2025, 1, 1),
+        LocalDate.of(2025, 12, 31)
+    )
+
+    @BeforeEach
+    fun setUp() {
+        springDataJpaRepository.deleteAll()
+        entityManager.flush()
+        entityManager.clear()
+    }
+
+    @Nested
+    @DisplayName("save")
+    inner class Save {
+
+        @Test
+        @DisplayName("라이선스를 저장할 수 있다")
+        fun `save license successfully`() {
+            // Given
+            val license = License.create(
+                planId = defaultPlanId,
+                owner = defaultOwner,
+                period = defaultPeriod
+            )
+
+            // When
+            val saved = licenseRepository.save(license)
+
+            // Then
+            assertThat(saved.id).isEqualTo(license.id)
+            assertThat(saved.planId).isEqualTo(defaultPlanId)
+            assertThat(saved.owner).isEqualTo(defaultOwner)
+            assertThat(saved.period).isEqualTo(defaultPeriod)
+            assertThat(saved.deleted).isFalse()
+        }
+    }
+
+    @Nested
+    @DisplayName("update")
+    inner class Update {
+
+        @Test
+        @DisplayName("라이선스를 만료시킬 수 있다")
+        fun `update license to expired`() {
+            // Given
+            val license = License.create(
+                planId = defaultPlanId,
+                owner = defaultOwner,
+                period = defaultPeriod
+            )
+            licenseRepository.save(license)
+
+            val expired = license.expire()
+
+            // When
+            val result = licenseRepository.update(expired)
+
+            // Then
+            assertThat(result.status.isExpired()).isTrue()
+        }
+    }
+
+    @Nested
+    @DisplayName("delete")
+    inner class Delete {
+
+        @Test
+        @DisplayName("라이선스를 삭제할 수 있다")
+        fun `delete license successfully`() {
+            // Given
+            val license = License.create(
+                planId = defaultPlanId,
+                owner = defaultOwner,
+                period = defaultPeriod
+            )
+            licenseRepository.save(license)
+
+            val deleted = license.delete()
+
+            // When
+            val result = licenseRepository.delete(deleted)
+
+            // Then
+            assertThat(result.deleted).isTrue()
+        }
+    }
+
+    @Nested
+    @DisplayName("loadById")
+    inner class LoadById {
+
+        @Test
+        @DisplayName("ID로 라이선스를 로드할 수 있다")
+        fun `load license by id successfully`() {
+            // Given
+            val license = License.create(
+                planId = defaultPlanId,
+                owner = defaultOwner,
+                period = defaultPeriod
+            )
+            licenseRepository.save(license)
+
+            // When
+            val result = licenseRepository.loadById(license.id)
+
+            // Then
+            assertThat(result.id).isEqualTo(license.id)
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 ID로 로드하면 예외가 발생한다")
+        fun `throw exception when license not found`() {
+            // Given
+            val licenseId = LicenseId.generate()
+
+            // When & Then
+            assertThatThrownBy {
+                licenseRepository.loadById(licenseId)
+            }.isInstanceOf(LicenseException::class.java)
+                .extracting("errorCode")
+                .isEqualTo(LicenseErrorCode.LICENSE_NOT_FOUND)
+        }
+
+        @Test
+        @DisplayName("삭제된 라이선스는 조회되지 않는다")
+        fun `throw exception when license is deleted`() {
+            // Given
+            val license = License.create(
+                planId = defaultPlanId,
+                owner = defaultOwner,
+                period = defaultPeriod
+            )
+            licenseRepository.save(license)
+            licenseRepository.delete(license.delete())
+
+            // When & Then
+            assertThatThrownBy {
+                licenseRepository.loadById(license.id)
+            }.isInstanceOf(LicenseException::class.java)
+                .extracting("errorCode")
+                .isEqualTo(LicenseErrorCode.LICENSE_NOT_FOUND)
+        }
+    }
+
+    @Nested
+    @DisplayName("loadByOwner")
+    inner class LoadByOwner {
+
+        @Test
+        @DisplayName("소유자로 라이선스 목록을 조회할 수 있다")
+        fun `load licenses by owner successfully`() {
+            // Given
+            val owner = Owner.user("user-456")
+            val license1 = License.create(
+                planId = defaultPlanId,
+                owner = owner,
+                period = defaultPeriod
+            )
+            val license2 = License.create(
+                planId = PlanId.generate(),
+                owner = owner,
+                period = defaultPeriod
+            )
+            licenseRepository.save(license1)
+            licenseRepository.save(license2)
+
+            // When
+            val result = licenseRepository.loadByOwner(owner)
+
+            // Then
+            assertThat(result).hasSize(2)
+            assertThat(result.map { it.id }).containsExactlyInAnyOrder(license1.id, license2.id)
+        }
+
+        @Test
+        @DisplayName("다른 소유자의 라이선스는 조회되지 않는다")
+        fun `not load other owner licenses`() {
+            // Given
+            val owner1 = Owner.user("user-111")
+            val owner2 = Owner.user("user-222")
+            val license1 = License.create(
+                planId = defaultPlanId,
+                owner = owner1,
+                period = defaultPeriod
+            )
+            val license2 = License.create(
+                planId = defaultPlanId,
+                owner = owner2,
+                period = defaultPeriod
+            )
+            licenseRepository.save(license1)
+            licenseRepository.save(license2)
+
+            // When
+            val result = licenseRepository.loadByOwner(owner1)
+
+            // Then
+            assertThat(result).hasSize(1)
+            assertThat(result[0].owner).isEqualTo(owner1)
+        }
+
+        @Test
+        @DisplayName("삭제된 라이선스는 목록에서 제외된다")
+        fun `exclude deleted licenses from list`() {
+            // Given
+            val owner = Owner.organization("org-123")
+            val license1 = License.create(
+                planId = defaultPlanId,
+                owner = owner,
+                period = defaultPeriod
+            )
+            val license2 = License.create(
+                planId = PlanId.generate(),
+                owner = owner,
+                period = defaultPeriod
+            )
+            licenseRepository.save(license1)
+            licenseRepository.save(license2)
+            licenseRepository.delete(license2.delete())
+
+            // When
+            val result = licenseRepository.loadByOwner(owner)
+
+            // Then
+            assertThat(result).hasSize(1)
+            assertThat(result[0].id).isEqualTo(license1.id)
+        }
+
+        @Test
+        @DisplayName("라이선스가 없으면 빈 목록을 반환한다")
+        fun `return empty list when no licenses exist`() {
+            // Given
+            val owner = Owner.user("user-999")
+
+            // When
+            val result = licenseRepository.loadByOwner(owner)
+
+            // Then
+            assertThat(result).isEmpty()
+        }
+    }
+
+    @Nested
+    @DisplayName("loadByIdIncludeDeleted")
+    inner class LoadByIdIncludeDeleted {
+
+        @Test
+        @DisplayName("아직 구현되지 않은 기능이므로 예외가 발생한다")
+        fun `throw not implemented exception`() {
+            // Given
+            val licenseId = LicenseId.generate()
+
+            // When & Then
+            assertThatThrownBy {
+                licenseRepository.loadByIdIncludeDeleted(licenseId)
+            }.isInstanceOf(CustomException::class.java)
+                .extracting("errorCode")
+                .isEqualTo(CommonErrorCode.NOT_IMPLEMENTED)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- License 도메인 모델 구현 (License, LicenseId, LicenseStatus, Owner, Period, LicensePolicy)
- JPA 인프라 레이어 구현 (Soft Delete, Repository Adapter)

## 주요 구현 사항

### 도메인 레이어
- `LicensePolicy`: 검증 로직 분리 (Period, Owner 유효성 검증)
- `reconstitute()`: 검증 생략 - DB 복원 시 장애 전파 방지
- `Owner`: Value Object로 type(USER/ORGANIZATION)과 id를 캡슐화

### 비즈니스 규칙
| 규칙 | 설명 |
|-----|-----|
| Period | startDate ≤ endDate |
| Owner.id | 비어있지 않은 문자열 |
| License 상태 | ACTIVE → EXPIRED 단방향 전이만 허용 |
| Soft Delete | 이미 삭제된 라이선스 재삭제 불가 |

### 인프라 레이어
- `ownerId`: 외부 시스템 ID이므로 UUID 대신 String 타입 사용
- `Owner`, `Period` VO를 컬럼으로 분리 저장 (ownerType, ownerId, startDate, endDate)
- 기본 조회는 `deleted=false`만 대상

### 테스트
- License 도메인 단위 테스트 (생성, 만료, 삭제, 유효성 검증)
- Value Object 테스트 (LicenseId, Owner, Period)
- LicenseRepositoryJpaAdapter 통합 테스트 (CRUD, soft delete)

Closes #28