### PR TITLE
feat: License 도메인 캡슐화 및 Plan 검증 강화

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### Claude Code ###
+.claude/

--- a/src/main/kotlin/com/flab/license/api/license/LicenseController.kt
+++ b/src/main/kotlin/com/flab/license/api/license/LicenseController.kt
@@ -1,0 +1,61 @@
+package com.flab.license.api.license
+
+import com.flab.license.api.license.dto.CreateLicenseRequest
+import com.flab.license.api.license.dto.GetLicensesByOwnerQuery
+import com.flab.license.api.license.dto.LicenseResponse
+import com.flab.license.common.response.ApiResponse
+import com.flab.license.domain.license.LicenseId
+import com.flab.license.service.license.command.LicenseCommandService
+import com.flab.license.service.license.query.LicenseQueryService
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+import java.util.UUID
+
+@RestController
+@RequestMapping("/licenses")
+class LicenseController(
+    private val licenseCommandService: LicenseCommandService,
+    private val licenseQueryService: LicenseQueryService
+) {
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    fun create(@Valid @RequestBody request: CreateLicenseRequest): ApiResponse<LicenseResponse> {
+        val license = licenseCommandService.create(request.toCommand())
+        return ApiResponse.success(LicenseResponse.from(license))
+    }
+
+    @GetMapping("/{licenseId}")
+    fun getById(@PathVariable licenseId: UUID): ApiResponse<LicenseResponse> {
+        val license = licenseQueryService.getById(LicenseId(licenseId))
+        return ApiResponse.success(LicenseResponse.from(license))
+    }
+
+    @GetMapping
+    fun getByOwner(
+        @Valid query: GetLicensesByOwnerQuery
+    ): ApiResponse<List<LicenseResponse>> {
+        val licenses = licenseQueryService.getByOwner(query.toOwner())
+        return ApiResponse.success(licenses.map { LicenseResponse.from(it) })
+    }
+
+    @PostMapping("/{licenseId}/expire")
+    fun expire(@PathVariable licenseId: UUID): ApiResponse<LicenseResponse> {
+        val license = licenseCommandService.expire(LicenseId(licenseId))
+        return ApiResponse.success(LicenseResponse.from(license))
+    }
+
+    @DeleteMapping("/{licenseId}")
+    fun delete(@PathVariable licenseId: UUID): ApiResponse<Unit> {
+        licenseCommandService.delete(LicenseId(licenseId))
+        return ApiResponse.ok()
+    }
+}

--- a/src/main/kotlin/com/flab/license/api/license/dto/CreateLicenseRequest.kt
+++ b/src/main/kotlin/com/flab/license/api/license/dto/CreateLicenseRequest.kt
@@ -1,0 +1,41 @@
+package com.flab.license.api.license.dto
+
+import com.flab.license.common.validation.EnumValue
+import com.flab.license.domain.license.Owner
+import com.flab.license.domain.license.Period
+import com.flab.license.domain.plan.PlanId
+import com.flab.license.service.license.command.CreateLicenseCommand
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
+import java.time.LocalDate
+import java.util.UUID
+
+data class CreateLicenseRequest(
+    @field:NotNull(message = "플랜 ID는 필수입니다")
+    val planId: UUID,
+
+    @field:EnumValue(enumClass = Owner.Type::class, ignoreCase = true, message = "유효한 소유자 타입이 아닙니다")
+    val ownerType: String,
+
+    @field:NotBlank(message = "소유자 ID는 필수입니다")
+    val ownerId: String,
+
+    @field:NotNull(message = "시작일은 필수입니다")
+    val startDate: LocalDate,
+
+    @field:NotNull(message = "종료일은 필수입니다")
+    val endDate: LocalDate
+) {
+    fun toCommand(): CreateLicenseCommand {
+        val ownerTypeEnum = Owner.Type.valueOf(ownerType.uppercase())
+        val owner = when (ownerTypeEnum) {
+            Owner.Type.USER -> Owner.user(ownerId)
+            Owner.Type.ORGANIZATION -> Owner.organization(ownerId)
+        }
+        return CreateLicenseCommand(
+            planId = PlanId(planId),
+            owner = owner,
+            period = Period.of(startDate, endDate)
+        )
+    }
+}

--- a/src/main/kotlin/com/flab/license/api/license/dto/GetLicensesByOwnerQuery.kt
+++ b/src/main/kotlin/com/flab/license/api/license/dto/GetLicensesByOwnerQuery.kt
@@ -1,0 +1,21 @@
+package com.flab.license.api.license.dto
+
+import com.flab.license.common.validation.EnumValue
+import com.flab.license.domain.license.Owner
+import jakarta.validation.constraints.NotBlank
+
+data class GetLicensesByOwnerQuery(
+    @field:EnumValue(enumClass = Owner.Type::class, ignoreCase = true, message = "유효한 소유자 타입이 아닙니다")
+    val ownerType: String,
+
+    @field:NotBlank(message = "소유자 ID는 필수입니다")
+    val ownerId: String
+) {
+    fun toOwner(): Owner {
+        val type = Owner.Type.valueOf(ownerType.uppercase())
+        return when (type) {
+            Owner.Type.USER -> Owner.user(ownerId)
+            Owner.Type.ORGANIZATION -> Owner.organization(ownerId)
+        }
+    }
+}

--- a/src/main/kotlin/com/flab/license/api/license/dto/LicenseResponse.kt
+++ b/src/main/kotlin/com/flab/license/api/license/dto/LicenseResponse.kt
@@ -1,0 +1,31 @@
+package com.flab.license.api.license.dto
+
+import com.flab.license.domain.license.License
+import com.flab.license.domain.license.LicenseStatus
+import com.flab.license.domain.license.Owner
+import java.time.LocalDate
+import java.util.UUID
+
+data class LicenseResponse(
+    val id: UUID,
+    val planId: UUID,
+    val ownerType: Owner.Type,
+    val ownerId: String,
+    val status: LicenseStatus,
+    val startDate: LocalDate,
+    val endDate: LocalDate
+) {
+    companion object {
+        fun from(license: License): LicenseResponse {
+            return LicenseResponse(
+                id = license.id.value,
+                planId = license.planId.value,
+                ownerType = license.owner.type,
+                ownerId = license.owner.id,
+                status = license.status,
+                startDate = license.period.startDate,
+                endDate = license.period.endDate
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/flab/license/domain/license/License.kt
+++ b/src/main/kotlin/com/flab/license/domain/license/License.kt
@@ -1,6 +1,7 @@
 package com.flab.license.domain.license
 
 import com.flab.license.domain.plan.PlanId
+import java.time.LocalDate
 
 class License private constructor(
     val id: LicenseId,
@@ -33,6 +34,10 @@ class License private constructor(
             period = this.period,
             deleted = true
         )
+    }
+
+    fun validateUsable(date: LocalDate = LocalDate.now()) {
+        LicensePolicy.validateUsable(status, deleted, period, date)
     }
 
     companion object {

--- a/src/main/kotlin/com/flab/license/service/license/command/CreateLicenseCommand.kt
+++ b/src/main/kotlin/com/flab/license/service/license/command/CreateLicenseCommand.kt
@@ -1,0 +1,11 @@
+package com.flab.license.service.license.command
+
+import com.flab.license.domain.license.Owner
+import com.flab.license.domain.license.Period
+import com.flab.license.domain.plan.PlanId
+
+data class CreateLicenseCommand(
+    val planId: PlanId,
+    val owner: Owner,
+    val period: Period
+)

--- a/src/main/kotlin/com/flab/license/service/license/command/LicenseCommandService.kt
+++ b/src/main/kotlin/com/flab/license/service/license/command/LicenseCommandService.kt
@@ -3,16 +3,20 @@ package com.flab.license.service.license.command
 import com.flab.license.domain.license.License
 import com.flab.license.domain.license.LicenseId
 import com.flab.license.domain.license.LicenseRepository
+import com.flab.license.service.plan.query.PlanQueryService
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
 @Service
 class LicenseCommandService(
-    private val licenseRepository: LicenseRepository
+    private val licenseRepository: LicenseRepository,
+    private val planQueryService: PlanQueryService
 ) {
 
     @Transactional
     fun create(command: CreateLicenseCommand): License {
+        planQueryService.getById(command.planId)
+
         val license = License.create(
             planId = command.planId,
             owner = command.owner,

--- a/src/main/kotlin/com/flab/license/service/license/command/LicenseCommandService.kt
+++ b/src/main/kotlin/com/flab/license/service/license/command/LicenseCommandService.kt
@@ -1,0 +1,37 @@
+package com.flab.license.service.license.command
+
+import com.flab.license.domain.license.License
+import com.flab.license.domain.license.LicenseId
+import com.flab.license.domain.license.LicenseRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class LicenseCommandService(
+    private val licenseRepository: LicenseRepository
+) {
+
+    @Transactional
+    fun create(command: CreateLicenseCommand): License {
+        val license = License.create(
+            planId = command.planId,
+            owner = command.owner,
+            period = command.period
+        )
+        return licenseRepository.save(license)
+    }
+
+    @Transactional
+    fun expire(licenseId: LicenseId): License {
+        val license = licenseRepository.loadById(licenseId)
+        val expired = license.expire()
+        return licenseRepository.update(expired)
+    }
+
+    @Transactional
+    fun delete(licenseId: LicenseId) {
+        val license = licenseRepository.loadById(licenseId)
+        val deleted = license.delete()
+        licenseRepository.delete(deleted)
+    }
+}

--- a/src/main/kotlin/com/flab/license/service/license/query/LicenseQueryService.kt
+++ b/src/main/kotlin/com/flab/license/service/license/query/LicenseQueryService.kt
@@ -1,0 +1,23 @@
+package com.flab.license.service.license.query
+
+import com.flab.license.domain.license.License
+import com.flab.license.domain.license.LicenseId
+import com.flab.license.domain.license.LicenseRepository
+import com.flab.license.domain.license.Owner
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional(readOnly = true)
+class LicenseQueryService(
+    private val licenseRepository: LicenseRepository
+) {
+
+    fun getById(licenseId: LicenseId): License {
+        return licenseRepository.loadById(licenseId)
+    }
+
+    fun getByOwner(owner: Owner): List<License> {
+        return licenseRepository.loadByOwner(owner)
+    }
+}

--- a/src/test/kotlin/com/flab/license/api/license/LicenseControllerTest.kt
+++ b/src/test/kotlin/com/flab/license/api/license/LicenseControllerTest.kt
@@ -1,0 +1,563 @@
+package com.flab.license.api.license
+
+import com.epages.restdocs.apispec.ResourceDocumentation.parameterWithName
+import com.epages.restdocs.apispec.ResourceDocumentation.resource
+import com.epages.restdocs.apispec.ResourceSnippetParameters
+import com.flab.license.api.AbstractRestDocsTest
+import com.flab.license.api.CommonResponseFields.success
+import com.flab.license.api.license.dto.CreateLicenseRequest
+import com.flab.license.domain.license.License
+import com.flab.license.domain.license.LicenseRepository
+import com.flab.license.domain.license.Owner
+import com.flab.license.domain.license.Period
+import com.flab.license.domain.plan.Plan
+import com.flab.license.domain.plan.PlanCode
+import com.flab.license.domain.plan.PlanRepository
+import com.flab.license.infra.persistence.license.jpa.LicenseSpringDataJpaRepository
+import com.flab.license.infra.persistence.plan.jpa.PlanSpringDataJpaRepository
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.MediaType
+import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders
+import org.springframework.restdocs.payload.JsonFieldType
+import org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath
+import org.springframework.restdocs.request.RequestDocumentation.parameterWithName as queryParamWithName
+import org.springframework.restdocs.request.RequestDocumentation.queryParameters
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import java.time.LocalDate
+import java.util.UUID
+
+@DisplayName("License API")
+class LicenseControllerTest : AbstractRestDocsTest() {
+
+    @Autowired
+    private lateinit var licenseRepository: LicenseRepository
+
+    @Autowired
+    private lateinit var planRepository: PlanRepository
+
+    @Autowired
+    private lateinit var licenseSpringDataJpaRepository: LicenseSpringDataJpaRepository
+
+    @Autowired
+    private lateinit var planSpringDataJpaRepository: PlanSpringDataJpaRepository
+
+    @AfterEach
+    fun tearDown() {
+        licenseSpringDataJpaRepository.deleteAll()
+        planSpringDataJpaRepository.deleteAll()
+    }
+
+    @Test
+    @DisplayName("POST /licenses - 라이선스 생성 성공")
+    fun createLicense_success() {
+        // Given
+        val plan = Plan.create(PlanCode.ENTERPRISE, 100, 1_000_000)
+        planRepository.save(plan)
+
+        val request = CreateLicenseRequest(
+            planId = plan.id.value,
+            ownerType = "USER",
+            ownerId = "user-123",
+            startDate = LocalDate.of(2025, 1, 1),
+            endDate = LocalDate.of(2025, 12, 31)
+        )
+
+        // When & Then
+        mockMvc
+            .perform(
+                RestDocumentationRequestBuilders
+                    .post("/licenses")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request))
+            )
+            .andExpect(status().isCreated)
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.data.planId").value(plan.id.value.toString()))
+            .andExpect(jsonPath("$.data.ownerType").value("USER"))
+            .andExpect(jsonPath("$.data.ownerId").value("user-123"))
+            .andExpect(jsonPath("$.data.status").value("ACTIVE"))
+            .andExpect(jsonPath("$.data.startDate").value("2025-01-01"))
+            .andExpect(jsonPath("$.data.endDate").value("2025-12-31"))
+            .andDo(
+                document(
+                    "license-create",
+                    resource(
+                        ResourceSnippetParameters
+                            .builder()
+                            .tag("License")
+                            .summary("라이선스 생성")
+                            .description("새로운 라이선스를 생성합니다.")
+                            .requestFields(
+                                fieldWithPath("planId")
+                                    .type(JsonFieldType.STRING)
+                                    .description("플랜 ID (UUID)"),
+                                fieldWithPath("ownerType")
+                                    .type(JsonFieldType.STRING)
+                                    .description("소유자 타입 (USER, ORGANIZATION)"),
+                                fieldWithPath("ownerId")
+                                    .type(JsonFieldType.STRING)
+                                    .description("소유자 ID"),
+                                fieldWithPath("startDate")
+                                    .type(JsonFieldType.STRING)
+                                    .description("시작일 (YYYY-MM-DD)"),
+                                fieldWithPath("endDate")
+                                    .type(JsonFieldType.STRING)
+                                    .description("종료일 (YYYY-MM-DD)")
+                            )
+                            .responseFields(
+                                success() + listOf(
+                                    fieldWithPath("data.id")
+                                        .type(JsonFieldType.STRING)
+                                        .description("라이선스 ID (UUID)"),
+                                    fieldWithPath("data.planId")
+                                        .type(JsonFieldType.STRING)
+                                        .description("플랜 ID (UUID)"),
+                                    fieldWithPath("data.ownerType")
+                                        .type(JsonFieldType.STRING)
+                                        .description("소유자 타입 (USER, ORGANIZATION)"),
+                                    fieldWithPath("data.ownerId")
+                                        .type(JsonFieldType.STRING)
+                                        .description("소유자 ID"),
+                                    fieldWithPath("data.status")
+                                        .type(JsonFieldType.STRING)
+                                        .description("라이선스 상태 (ACTIVE, EXPIRED)"),
+                                    fieldWithPath("data.startDate")
+                                        .type(JsonFieldType.STRING)
+                                        .description("시작일 (YYYY-MM-DD)"),
+                                    fieldWithPath("data.endDate")
+                                        .type(JsonFieldType.STRING)
+                                        .description("종료일 (YYYY-MM-DD)")
+                                )
+                            )
+                            .build()
+                    )
+                )
+            )
+    }
+
+    @Test
+    @DisplayName("POST /licenses - 유효하지 않은 ownerType으로 생성 실패")
+    fun createLicense_invalidOwnerType_returnsError() {
+        // Given
+        val plan = Plan.create(PlanCode.ENTERPRISE, 100, 1_000_000)
+        planRepository.save(plan)
+
+        val request = mapOf(
+            "planId" to plan.id.value.toString(),
+            "ownerType" to "INVALID",
+            "ownerId" to "user-123",
+            "startDate" to "2025-01-01",
+            "endDate" to "2025-12-31"
+        )
+
+        // When & Then
+        mockMvc
+            .perform(
+                RestDocumentationRequestBuilders
+                    .post("/licenses")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request))
+            )
+            .andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.success").value(false))
+            .andExpect(jsonPath("$.error").exists())
+    }
+
+    @Test
+    @DisplayName("POST /licenses - 필수 필드 누락 시 생성 실패")
+    fun createLicense_missingRequiredField_returnsError() {
+        // Given
+        val request = mapOf(
+            "ownerType" to "USER",
+            "ownerId" to "user-123",
+            "startDate" to "2025-01-01",
+            "endDate" to "2025-12-31"
+            // planId 누락
+        )
+
+        // When & Then
+        mockMvc
+            .perform(
+                RestDocumentationRequestBuilders
+                    .post("/licenses")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request))
+            )
+            .andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.success").value(false))
+            .andExpect(jsonPath("$.error").exists())
+    }
+
+    @Test
+    @DisplayName("GET /licenses/{licenseId} - 라이선스 단건 조회 성공")
+    fun getLicenseById_success() {
+        // Given
+        val plan = Plan.create(PlanCode.PRO, 1, 100_000)
+        planRepository.save(plan)
+
+        val license = License.create(
+            planId = plan.id,
+            owner = Owner.user("user-456"),
+            period = Period.of(
+                LocalDate.of(2025, 1, 1),
+                LocalDate.of(2025, 12, 31)
+            )
+        )
+        licenseRepository.save(license)
+
+        // When & Then
+        mockMvc
+            .perform(
+                RestDocumentationRequestBuilders
+                    .get("/licenses/{licenseId}", license.id.value)
+                    .contentType(MediaType.APPLICATION_JSON)
+            )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.data.id").value(license.id.value.toString()))
+            .andExpect(jsonPath("$.data.planId").value(plan.id.value.toString()))
+            .andExpect(jsonPath("$.data.ownerType").value("USER"))
+            .andExpect(jsonPath("$.data.ownerId").value("user-456"))
+            .andExpect(jsonPath("$.data.status").value("ACTIVE"))
+            .andDo(
+                document(
+                    "license-get-by-id",
+                    resource(
+                        ResourceSnippetParameters
+                            .builder()
+                            .tag("License")
+                            .summary("라이선스 단건 조회")
+                            .description("ID로 라이선스를 조회합니다.")
+                            .pathParameters(
+                                parameterWithName("licenseId")
+                                    .description("라이선스 ID (UUID)")
+                            )
+                            .responseFields(
+                                success() + listOf(
+                                    fieldWithPath("data.id")
+                                        .type(JsonFieldType.STRING)
+                                        .description("라이선스 ID (UUID)"),
+                                    fieldWithPath("data.planId")
+                                        .type(JsonFieldType.STRING)
+                                        .description("플랜 ID (UUID)"),
+                                    fieldWithPath("data.ownerType")
+                                        .type(JsonFieldType.STRING)
+                                        .description("소유자 타입 (USER, ORGANIZATION)"),
+                                    fieldWithPath("data.ownerId")
+                                        .type(JsonFieldType.STRING)
+                                        .description("소유자 ID"),
+                                    fieldWithPath("data.status")
+                                        .type(JsonFieldType.STRING)
+                                        .description("라이선스 상태 (ACTIVE, EXPIRED)"),
+                                    fieldWithPath("data.startDate")
+                                        .type(JsonFieldType.STRING)
+                                        .description("시작일 (YYYY-MM-DD)"),
+                                    fieldWithPath("data.endDate")
+                                        .type(JsonFieldType.STRING)
+                                        .description("종료일 (YYYY-MM-DD)")
+                                )
+                            )
+                            .build()
+                    )
+                )
+            )
+    }
+
+    @Test
+    @DisplayName("GET /licenses/{licenseId} - 존재하지 않는 라이선스 조회 실패")
+    fun getLicenseById_notFound_returnsError() {
+        // Given
+        val nonExistentId = UUID.randomUUID()
+
+        // When & Then
+        mockMvc
+            .perform(
+                RestDocumentationRequestBuilders
+                    .get("/licenses/{licenseId}", nonExistentId)
+                    .contentType(MediaType.APPLICATION_JSON)
+            )
+            .andExpect(status().isNotFound)
+            .andExpect(jsonPath("$.success").value(false))
+            .andExpect(jsonPath("$.error").exists())
+    }
+
+    @Test
+    @DisplayName("GET /licenses?ownerType=&ownerId= - 소유자별 라이선스 목록 조회 성공")
+    fun getLicensesByOwner_success() {
+        // Given
+        val plan = Plan.create(PlanCode.ENTERPRISE, 100, 1_000_000)
+        planRepository.save(plan)
+
+        val license1 = License.create(
+            planId = plan.id,
+            owner = Owner.user("user-789"),
+            period = Period.of(
+                LocalDate.of(2025, 1, 1),
+                LocalDate.of(2025, 6, 30)
+            )
+        )
+        val license2 = License.create(
+            planId = plan.id,
+            owner = Owner.user("user-789"),
+            period = Period.of(
+                LocalDate.of(2025, 7, 1),
+                LocalDate.of(2025, 12, 31)
+            )
+        )
+        licenseRepository.save(license1)
+        licenseRepository.save(license2)
+
+        // When & Then
+        mockMvc
+            .perform(
+                RestDocumentationRequestBuilders
+                    .get("/licenses")
+                    .param("ownerType", "USER")
+                    .param("ownerId", "user-789")
+                    .contentType(MediaType.APPLICATION_JSON)
+            )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.data").isArray)
+            .andExpect(jsonPath("$.data.length()").value(2))
+            .andExpect(jsonPath("$.data[0].ownerId").value("user-789"))
+            .andExpect(jsonPath("$.data[1].ownerId").value("user-789"))
+            .andDo(
+                document(
+                    "license-get-by-owner",
+                    resource(
+                        ResourceSnippetParameters
+                            .builder()
+                            .tag("License")
+                            .summary("소유자별 라이선스 목록 조회")
+                            .description("소유자 타입과 ID로 라이선스 목록을 조회합니다.")
+                            .queryParameters(
+                                queryParamWithName("ownerType")
+                                    .description("소유자 타입 (USER, ORGANIZATION)"),
+                                queryParamWithName("ownerId")
+                                    .description("소유자 ID")
+                            )
+                            .responseFields(
+                                success() + listOf(
+                                    fieldWithPath("data[]")
+                                        .type(JsonFieldType.ARRAY)
+                                        .description("라이선스 목록"),
+                                    fieldWithPath("data[].id")
+                                        .type(JsonFieldType.STRING)
+                                        .description("라이선스 ID (UUID)"),
+                                    fieldWithPath("data[].planId")
+                                        .type(JsonFieldType.STRING)
+                                        .description("플랜 ID (UUID)"),
+                                    fieldWithPath("data[].ownerType")
+                                        .type(JsonFieldType.STRING)
+                                        .description("소유자 타입 (USER, ORGANIZATION)"),
+                                    fieldWithPath("data[].ownerId")
+                                        .type(JsonFieldType.STRING)
+                                        .description("소유자 ID"),
+                                    fieldWithPath("data[].status")
+                                        .type(JsonFieldType.STRING)
+                                        .description("라이선스 상태 (ACTIVE, EXPIRED)"),
+                                    fieldWithPath("data[].startDate")
+                                        .type(JsonFieldType.STRING)
+                                        .description("시작일 (YYYY-MM-DD)"),
+                                    fieldWithPath("data[].endDate")
+                                        .type(JsonFieldType.STRING)
+                                        .description("종료일 (YYYY-MM-DD)")
+                                )
+                            )
+                            .build()
+                    )
+                )
+            )
+    }
+
+    @Test
+    @DisplayName("GET /licenses?ownerType=&ownerId= - 유효하지 않은 ownerType으로 조회 실패")
+    fun getLicensesByOwner_invalidOwnerType_returnsError() {
+        // When & Then
+        mockMvc
+            .perform(
+                RestDocumentationRequestBuilders
+                    .get("/licenses")
+                    .param("ownerType", "INVALID")
+                    .param("ownerId", "user-789")
+                    .contentType(MediaType.APPLICATION_JSON)
+            )
+            .andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.success").value(false))
+            .andExpect(jsonPath("$.error").exists())
+    }
+
+    @Test
+    @DisplayName("POST /licenses/{licenseId}/expire - 라이선스 만료 처리 성공")
+    fun expireLicense_success() {
+        // Given
+        val plan = Plan.create(PlanCode.PRO, 1, 100_000)
+        planRepository.save(plan)
+
+        val license = License.create(
+            planId = plan.id,
+            owner = Owner.organization("org-100"),
+            period = Period.of(
+                LocalDate.of(2025, 1, 1),
+                LocalDate.of(2025, 12, 31)
+            )
+        )
+        licenseRepository.save(license)
+
+        // When & Then
+        mockMvc
+            .perform(
+                RestDocumentationRequestBuilders
+                    .post("/licenses/{licenseId}/expire", license.id.value)
+                    .contentType(MediaType.APPLICATION_JSON)
+            )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.data.id").value(license.id.value.toString()))
+            .andExpect(jsonPath("$.data.status").value("EXPIRED"))
+            .andDo(
+                document(
+                    "license-expire",
+                    resource(
+                        ResourceSnippetParameters
+                            .builder()
+                            .tag("License")
+                            .summary("라이선스 만료 처리")
+                            .description("라이선스를 만료 상태로 변경합니다.")
+                            .pathParameters(
+                                parameterWithName("licenseId")
+                                    .description("라이선스 ID (UUID)")
+                            )
+                            .responseFields(
+                                success() + listOf(
+                                    fieldWithPath("data.id")
+                                        .type(JsonFieldType.STRING)
+                                        .description("라이선스 ID (UUID)"),
+                                    fieldWithPath("data.planId")
+                                        .type(JsonFieldType.STRING)
+                                        .description("플랜 ID (UUID)"),
+                                    fieldWithPath("data.ownerType")
+                                        .type(JsonFieldType.STRING)
+                                        .description("소유자 타입 (USER, ORGANIZATION)"),
+                                    fieldWithPath("data.ownerId")
+                                        .type(JsonFieldType.STRING)
+                                        .description("소유자 ID"),
+                                    fieldWithPath("data.status")
+                                        .type(JsonFieldType.STRING)
+                                        .description("라이선스 상태 (EXPIRED)"),
+                                    fieldWithPath("data.startDate")
+                                        .type(JsonFieldType.STRING)
+                                        .description("시작일 (YYYY-MM-DD)"),
+                                    fieldWithPath("data.endDate")
+                                        .type(JsonFieldType.STRING)
+                                        .description("종료일 (YYYY-MM-DD)")
+                                )
+                            )
+                            .build()
+                    )
+                )
+            )
+    }
+
+    @Test
+    @DisplayName("POST /licenses/{licenseId}/expire - 이미 만료된 라이선스 만료 처리 실패")
+    fun expireLicense_alreadyExpired_returnsError() {
+        // Given
+        val plan = Plan.create(PlanCode.PRO, 1, 100_000)
+        planRepository.save(plan)
+
+        val license = License.create(
+            planId = plan.id,
+            owner = Owner.user("user-999"),
+            period = Period.of(
+                LocalDate.of(2025, 1, 1),
+                LocalDate.of(2025, 12, 31)
+            )
+        )
+        val expiredLicense = license.expire()
+        licenseRepository.save(expiredLicense)
+
+        // When & Then
+        mockMvc
+            .perform(
+                RestDocumentationRequestBuilders
+                    .post("/licenses/{licenseId}/expire", expiredLicense.id.value)
+                    .contentType(MediaType.APPLICATION_JSON)
+            )
+            .andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.success").value(false))
+            .andExpect(jsonPath("$.error").exists())
+    }
+
+    @Test
+    @DisplayName("DELETE /licenses/{licenseId} - 라이선스 삭제 성공")
+    fun deleteLicense_success() {
+        // Given
+        val plan = Plan.create(PlanCode.ENTERPRISE, 100, 1_000_000)
+        planRepository.save(plan)
+
+        val license = License.create(
+            planId = plan.id,
+            owner = Owner.user("user-888"),
+            period = Period.of(
+                LocalDate.of(2025, 1, 1),
+                LocalDate.of(2025, 12, 31)
+            )
+        )
+        licenseRepository.save(license)
+
+        // When & Then
+        mockMvc
+            .perform(
+                RestDocumentationRequestBuilders
+                    .delete("/licenses/{licenseId}", license.id.value)
+                    .contentType(MediaType.APPLICATION_JSON)
+            )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.success").value(true))
+            .andDo(
+                document(
+                    "license-delete",
+                    resource(
+                        ResourceSnippetParameters
+                            .builder()
+                            .tag("License")
+                            .summary("라이선스 삭제")
+                            .description("라이선스를 삭제합니다.")
+                            .pathParameters(
+                                parameterWithName("licenseId")
+                                    .description("라이선스 ID (UUID)")
+                            )
+                            .responseFields(
+                                success()
+                            )
+                            .build()
+                    )
+                )
+            )
+    }
+
+    @Test
+    @DisplayName("DELETE /licenses/{licenseId} - 존재하지 않는 라이선스 삭제 실패")
+    fun deleteLicense_notFound_returnsError() {
+        // Given
+        val nonExistentId = UUID.randomUUID()
+
+        // When & Then
+        mockMvc
+            .perform(
+                RestDocumentationRequestBuilders
+                    .delete("/licenses/{licenseId}", nonExistentId)
+                    .contentType(MediaType.APPLICATION_JSON)
+            )
+            .andExpect(status().isNotFound)
+            .andExpect(jsonPath("$.success").value(false))
+            .andExpect(jsonPath("$.error").exists())
+    }
+}

--- a/src/test/kotlin/com/flab/license/domain/license/LicenseTest.kt
+++ b/src/test/kotlin/com/flab/license/domain/license/LicenseTest.kt
@@ -4,6 +4,7 @@ import com.flab.license.domain.license.exception.LicenseErrorCode
 import com.flab.license.domain.license.exception.LicenseException
 import com.flab.license.domain.plan.PlanId
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatCode
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
@@ -383,6 +384,101 @@ class LicenseTest {
             assertThat(deletedLicense.planId).isEqualTo(originalPlanId)
             assertThat(deletedLicense.owner).isEqualTo(originalOwner)
             assertThat(deletedLicense.period).isEqualTo(originalPeriod)
+        }
+    }
+
+    @Nested
+    @DisplayName("validateUsable")
+    inner class ValidateUsable {
+
+        @Test
+        @DisplayName("ACTIVE 상태이고 기간 내이면 검증을 통과한다")
+        fun `pass validation when active and within period`() {
+            // Given
+            val license = License.create(
+                planId = defaultPlanId,
+                owner = defaultOwner,
+                period = defaultPeriod
+            )
+            val dateWithinPeriod = LocalDate.of(2025, 6, 15)
+
+            // When & Then
+            assertThatCode { license.validateUsable(dateWithinPeriod) }
+                .doesNotThrowAnyException()
+        }
+
+        @Test
+        @DisplayName("삭제된 라이선스는 검증에 실패한다")
+        fun `throw exception when license is deleted`() {
+            // Given
+            val license = License.create(
+                planId = defaultPlanId,
+                owner = defaultOwner,
+                period = defaultPeriod
+            )
+            val deletedLicense = license.delete()
+            val dateWithinPeriod = LocalDate.of(2025, 6, 15)
+
+            // When & Then
+            assertThatThrownBy { deletedLicense.validateUsable(dateWithinPeriod) }
+                .isInstanceOf(LicenseException::class.java)
+                .extracting("errorCode")
+                .isEqualTo(LicenseErrorCode.LICENSE_ALREADY_DELETED)
+        }
+
+        @Test
+        @DisplayName("EXPIRED 상태는 검증에 실패한다")
+        fun `throw exception when license status is expired`() {
+            // Given
+            val license = License.create(
+                planId = defaultPlanId,
+                owner = defaultOwner,
+                period = defaultPeriod
+            )
+            val expiredLicense = license.expire()
+            val dateWithinPeriod = LocalDate.of(2025, 6, 15)
+
+            // When & Then
+            assertThatThrownBy { expiredLicense.validateUsable(dateWithinPeriod) }
+                .isInstanceOf(LicenseException::class.java)
+                .extracting("errorCode")
+                .isEqualTo(LicenseErrorCode.LICENSE_NOT_ACTIVE)
+        }
+
+        @Test
+        @DisplayName("기간 시작 전이면 검증에 실패한다")
+        fun `throw exception when date is before period start`() {
+            // Given
+            val license = License.create(
+                planId = defaultPlanId,
+                owner = defaultOwner,
+                period = defaultPeriod
+            )
+            val dateBeforePeriod = LocalDate.of(2024, 12, 31)
+
+            // When & Then
+            assertThatThrownBy { license.validateUsable(dateBeforePeriod) }
+                .isInstanceOf(LicenseException::class.java)
+                .extracting("errorCode")
+                .isEqualTo(LicenseErrorCode.LICENSE_PERIOD_NOT_STARTED)
+        }
+
+        @Test
+        @DisplayName("기간 종료 후이면 검증에 실패한다")
+        fun `throw exception when date is after period end`() {
+            // Given
+            val license = License.create(
+                planId = defaultPlanId,
+                owner = defaultOwner,
+                period = defaultPeriod
+            )
+            val dateAfterPeriod = LocalDate.of(2026, 1, 1)
+
+            // When & Then
+            assertThatThrownBy { license.validateUsable(dateAfterPeriod) }
+                .isInstanceOf(LicenseException::class.java)
+                .extracting("errorCode")
+                .isEqualTo(LicenseErrorCode.LICENSE_PERIOD_ENDED)
         }
     }
 }

--- a/src/test/kotlin/com/flab/license/service/license/command/LicenseCommandServiceTest.kt
+++ b/src/test/kotlin/com/flab/license/service/license/command/LicenseCommandServiceTest.kt
@@ -3,7 +3,12 @@ package com.flab.license.service.license.command
 import com.flab.license.domain.license.*
 import com.flab.license.domain.license.exception.LicenseErrorCode
 import com.flab.license.domain.license.exception.LicenseException
+import com.flab.license.domain.plan.Plan
+import com.flab.license.domain.plan.PlanCode
 import com.flab.license.domain.plan.PlanId
+import com.flab.license.domain.plan.exception.PlanErrorCode
+import com.flab.license.domain.plan.exception.PlanException
+import com.flab.license.service.plan.query.PlanQueryService
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.BeforeEach
@@ -25,6 +30,9 @@ class LicenseCommandServiceTest {
     @Mock
     private lateinit var licenseRepository: LicenseRepository
 
+    @Mock
+    private lateinit var planQueryService: PlanQueryService
+
     private lateinit var licenseCommandService: LicenseCommandService
 
     private val defaultPlanId = PlanId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
@@ -36,7 +44,7 @@ class LicenseCommandServiceTest {
 
     @BeforeEach
     fun setUp() {
-        licenseCommandService = LicenseCommandService(licenseRepository)
+        licenseCommandService = LicenseCommandService(licenseRepository, planQueryService)
     }
 
     @Nested
@@ -52,6 +60,12 @@ class LicenseCommandServiceTest {
                 owner = defaultOwner,
                 period = defaultPeriod
             )
+            val mockPlan = Plan.create(
+                planCode = PlanCode.FREE,
+                maxSeats = 1,
+                monthlyTokenLimit = 100000L
+            )
+            given(planQueryService.getById(defaultPlanId)).willReturn(mockPlan)
             given(licenseRepository.save(any())).willAnswer { it.arguments[0] }
 
             // When
@@ -63,6 +77,7 @@ class LicenseCommandServiceTest {
             assertThat(result.owner).isEqualTo(defaultOwner)
             assertThat(result.period).isEqualTo(defaultPeriod)
             assertThat(result.deleted).isFalse()
+            verify(planQueryService).getById(defaultPlanId)
             verify(licenseRepository).save(any())
         }
 
@@ -76,6 +91,12 @@ class LicenseCommandServiceTest {
                 owner = orgOwner,
                 period = defaultPeriod
             )
+            val mockPlan = Plan.create(
+                planCode = PlanCode.PRO,
+                maxSeats = 1,
+                monthlyTokenLimit = 500000L
+            )
+            given(planQueryService.getById(defaultPlanId)).willReturn(mockPlan)
             given(licenseRepository.save(any())).willAnswer { it.arguments[0] }
 
             // When
@@ -85,7 +106,27 @@ class LicenseCommandServiceTest {
             assertThat(result.owner.type).isEqualTo(Owner.Type.ORGANIZATION)
             assertThat(result.owner.id).isEqualTo("org-456")
             assertThat(result.status).isEqualTo(LicenseStatus.ACTIVE)
+            verify(planQueryService).getById(defaultPlanId)
             verify(licenseRepository).save(any())
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 Plan으로 라이선스 생성 시 예외가 발생한다")
+        fun `throw exception when plan not found`() {
+            // Given
+            val command = CreateLicenseCommand(
+                planId = defaultPlanId,
+                owner = defaultOwner,
+                period = defaultPeriod
+            )
+            given(planQueryService.getById(defaultPlanId))
+                .willThrow(PlanException(PlanErrorCode.PLAN_NOT_FOUND))
+
+            // When & Then
+            assertThatThrownBy { licenseCommandService.create(command) }
+                .isInstanceOf(PlanException::class.java)
+                .extracting("errorCode")
+                .isEqualTo(PlanErrorCode.PLAN_NOT_FOUND)
         }
     }
 

--- a/src/test/kotlin/com/flab/license/service/license/command/LicenseCommandServiceTest.kt
+++ b/src/test/kotlin/com/flab/license/service/license/command/LicenseCommandServiceTest.kt
@@ -1,0 +1,265 @@
+package com.flab.license.service.license.command
+
+import com.flab.license.domain.license.*
+import com.flab.license.domain.license.exception.LicenseErrorCode
+import com.flab.license.domain.license.exception.LicenseException
+import com.flab.license.domain.plan.PlanId
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.given
+import org.mockito.kotlin.verify
+import java.time.LocalDate
+import java.util.*
+
+@ExtendWith(MockitoExtension::class)
+class LicenseCommandServiceTest {
+
+    @Mock
+    private lateinit var licenseRepository: LicenseRepository
+
+    private lateinit var licenseCommandService: LicenseCommandService
+
+    private val defaultPlanId = PlanId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
+    private val defaultOwner = Owner.user("user-123")
+    private val defaultPeriod = Period.of(
+        LocalDate.of(2025, 1, 1),
+        LocalDate.of(2025, 12, 31)
+    )
+
+    @BeforeEach
+    fun setUp() {
+        licenseCommandService = LicenseCommandService(licenseRepository)
+    }
+
+    @Nested
+    @DisplayName("create")
+    inner class Create {
+
+        @Test
+        @DisplayName("라이선스를 생성할 수 있다")
+        fun `create license successfully`() {
+            // Given
+            val command = CreateLicenseCommand(
+                planId = defaultPlanId,
+                owner = defaultOwner,
+                period = defaultPeriod
+            )
+            given(licenseRepository.save(any())).willAnswer { it.arguments[0] }
+
+            // When
+            val result = licenseCommandService.create(command)
+
+            // Then
+            assertThat(result.status).isEqualTo(LicenseStatus.ACTIVE)
+            assertThat(result.planId).isEqualTo(defaultPlanId)
+            assertThat(result.owner).isEqualTo(defaultOwner)
+            assertThat(result.period).isEqualTo(defaultPeriod)
+            assertThat(result.deleted).isFalse()
+            verify(licenseRepository).save(any())
+        }
+
+        @Test
+        @DisplayName("Organization 소유의 라이선스를 생성할 수 있다")
+        fun `create license for organization successfully`() {
+            // Given
+            val orgOwner = Owner.organization("org-456")
+            val command = CreateLicenseCommand(
+                planId = defaultPlanId,
+                owner = orgOwner,
+                period = defaultPeriod
+            )
+            given(licenseRepository.save(any())).willAnswer { it.arguments[0] }
+
+            // When
+            val result = licenseCommandService.create(command)
+
+            // Then
+            assertThat(result.owner.type).isEqualTo(Owner.Type.ORGANIZATION)
+            assertThat(result.owner.id).isEqualTo("org-456")
+            assertThat(result.status).isEqualTo(LicenseStatus.ACTIVE)
+            verify(licenseRepository).save(any())
+        }
+    }
+
+    @Nested
+    @DisplayName("expire")
+    inner class Expire {
+
+        @Test
+        @DisplayName("ACTIVE 라이선스를 만료시킬 수 있다")
+        fun `expire active license successfully`() {
+            // Given
+            val activeLicense = License.create(
+                planId = defaultPlanId,
+                owner = defaultOwner,
+                period = defaultPeriod
+            )
+            val expiredLicense = activeLicense.expire()
+
+            given(licenseRepository.loadById(activeLicense.id)).willReturn(activeLicense)
+            given(licenseRepository.update(any())).willReturn(expiredLicense)
+
+            // When
+            val result = licenseCommandService.expire(activeLicense.id)
+
+            // Then
+            assertThat(result.status).isEqualTo(LicenseStatus.EXPIRED)
+            assertThat(result.id).isEqualTo(activeLicense.id)
+            assertThat(result.planId).isEqualTo(activeLicense.planId)
+            assertThat(result.owner).isEqualTo(activeLicense.owner)
+            assertThat(result.period).isEqualTo(activeLicense.period)
+            verify(licenseRepository).loadById(activeLicense.id)
+            verify(licenseRepository).update(any())
+        }
+
+        @Test
+        @DisplayName("이미 만료된 라이선스를 만료시키면 예외가 발생한다")
+        fun `throw exception when expire already expired license`() {
+            // Given
+            val license = License.create(
+                planId = defaultPlanId,
+                owner = defaultOwner,
+                period = defaultPeriod
+            )
+            val expiredLicense = license.expire()
+
+            given(licenseRepository.loadById(expiredLicense.id)).willReturn(expiredLicense)
+
+            // When & Then
+            assertThatThrownBy {
+                licenseCommandService.expire(expiredLicense.id)
+            }.isInstanceOf(LicenseException::class.java)
+                .extracting("errorCode")
+                .isEqualTo(LicenseErrorCode.ALREADY_EXPIRED)
+        }
+
+        @Test
+        @DisplayName("삭제된 라이선스를 만료시키면 예외가 발생한다")
+        fun `throw exception when expire deleted license`() {
+            // Given
+            val license = License.create(
+                planId = defaultPlanId,
+                owner = defaultOwner,
+                period = defaultPeriod
+            )
+            val deletedLicense = license.delete()
+
+            given(licenseRepository.loadById(deletedLicense.id)).willReturn(deletedLicense)
+
+            // When & Then
+            assertThatThrownBy {
+                licenseCommandService.expire(deletedLicense.id)
+            }.isInstanceOf(LicenseException::class.java)
+                .extracting("errorCode")
+                .isEqualTo(LicenseErrorCode.LICENSE_ALREADY_DELETED)
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 라이선스를 만료시키면 예외가 발생한다")
+        fun `throw exception when license not found`() {
+            // Given
+            val licenseId = LicenseId(UUID.fromString("00000000-0000-0000-0000-000000000999"))
+            given(licenseRepository.loadById(licenseId)).willThrow(LicenseException(LicenseErrorCode.LICENSE_NOT_FOUND))
+
+            // When & Then
+            assertThatThrownBy {
+                licenseCommandService.expire(licenseId)
+            }.isInstanceOf(LicenseException::class.java)
+                .extracting("errorCode")
+                .isEqualTo(LicenseErrorCode.LICENSE_NOT_FOUND)
+        }
+    }
+
+    @Nested
+    @DisplayName("delete")
+    inner class Delete {
+
+        @Test
+        @DisplayName("라이선스를 삭제할 수 있다")
+        fun `delete license successfully`() {
+            // Given
+            val activeLicense = License.create(
+                planId = defaultPlanId,
+                owner = defaultOwner,
+                period = defaultPeriod
+            )
+            val deletedLicense = activeLicense.delete()
+
+            given(licenseRepository.loadById(activeLicense.id)).willReturn(activeLicense)
+            given(licenseRepository.delete(any())).willReturn(deletedLicense)
+
+            // When
+            licenseCommandService.delete(activeLicense.id)
+
+            // Then
+            verify(licenseRepository).loadById(activeLicense.id)
+            verify(licenseRepository).delete(any())
+        }
+
+        @Test
+        @DisplayName("만료된 라이선스도 삭제할 수 있다")
+        fun `delete expired license successfully`() {
+            // Given
+            val license = License.create(
+                planId = defaultPlanId,
+                owner = defaultOwner,
+                period = defaultPeriod
+            )
+            val expiredLicense = license.expire()
+
+            given(licenseRepository.loadById(expiredLicense.id)).willReturn(expiredLicense)
+            given(licenseRepository.delete(any())).willAnswer { it.arguments[0] }
+
+            // When
+            licenseCommandService.delete(expiredLicense.id)
+
+            // Then
+            verify(licenseRepository).loadById(expiredLicense.id)
+            verify(licenseRepository).delete(any())
+        }
+
+        @Test
+        @DisplayName("이미 삭제된 라이선스를 삭제하면 예외가 발생한다")
+        fun `throw exception when delete already deleted license`() {
+            // Given
+            val license = License.create(
+                planId = defaultPlanId,
+                owner = defaultOwner,
+                period = defaultPeriod
+            )
+            val deletedLicense = license.delete()
+
+            given(licenseRepository.loadById(deletedLicense.id)).willReturn(deletedLicense)
+
+            // When & Then
+            assertThatThrownBy {
+                licenseCommandService.delete(deletedLicense.id)
+            }.isInstanceOf(LicenseException::class.java)
+                .extracting("errorCode")
+                .isEqualTo(LicenseErrorCode.LICENSE_ALREADY_DELETED)
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 라이선스를 삭제하면 예외가 발생한다")
+        fun `throw exception when license not found`() {
+            // Given
+            val licenseId = LicenseId(UUID.fromString("00000000-0000-0000-0000-000000000999"))
+            given(licenseRepository.loadById(licenseId)).willThrow(LicenseException(LicenseErrorCode.LICENSE_NOT_FOUND))
+
+            // When & Then
+            assertThatThrownBy {
+                licenseCommandService.delete(licenseId)
+            }.isInstanceOf(LicenseException::class.java)
+                .extracting("errorCode")
+                .isEqualTo(LicenseErrorCode.LICENSE_NOT_FOUND)
+        }
+    }
+}

--- a/src/test/kotlin/com/flab/license/service/license/query/LicenseQueryServiceTest.kt
+++ b/src/test/kotlin/com/flab/license/service/license/query/LicenseQueryServiceTest.kt
@@ -1,0 +1,249 @@
+package com.flab.license.service.license.query
+
+import com.flab.license.domain.license.License
+import com.flab.license.domain.license.LicenseId
+import com.flab.license.domain.license.LicenseRepository
+import com.flab.license.domain.license.LicenseStatus
+import com.flab.license.domain.license.Owner
+import com.flab.license.domain.license.Period
+import com.flab.license.domain.license.exception.LicenseErrorCode
+import com.flab.license.domain.license.exception.LicenseException
+import com.flab.license.domain.plan.PlanId
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.given
+import java.time.LocalDate
+
+@ExtendWith(MockitoExtension::class)
+class LicenseQueryServiceTest {
+
+    @Mock
+    private lateinit var licenseRepository: LicenseRepository
+
+    private lateinit var sut: LicenseQueryService
+
+    private val defaultPlanId = PlanId.generate()
+    private val defaultOwner = Owner.user("user-123")
+    private val defaultPeriod = Period.of(
+        LocalDate.of(2025, 1, 1),
+        LocalDate.of(2025, 12, 31)
+    )
+
+    @BeforeEach
+    fun setUp() {
+        sut = LicenseQueryService(licenseRepository)
+    }
+
+    @Nested
+    @DisplayName("getById")
+    inner class GetById {
+
+        @Test
+        @DisplayName("ID로 라이선스를 조회할 수 있다")
+        fun `get license by id successfully`() {
+            // Given
+            val license = License.create(
+                planId = defaultPlanId,
+                owner = defaultOwner,
+                period = defaultPeriod
+            )
+            given(licenseRepository.loadById(license.id)).willReturn(license)
+
+            // When
+            val result = sut.getById(license.id)
+
+            // Then
+            assertThat(result.id).isEqualTo(license.id)
+            assertThat(result.status).isEqualTo(LicenseStatus.ACTIVE)
+            assertThat(result.owner).isEqualTo(defaultOwner)
+            assertThat(result.deleted).isFalse()
+        }
+
+        @Test
+        @DisplayName("조회한 라이선스의 플랜 ID가 일치한다")
+        fun `get license has correct plan id`() {
+            // Given
+            val license = License.create(
+                planId = defaultPlanId,
+                owner = defaultOwner,
+                period = defaultPeriod
+            )
+            given(licenseRepository.loadById(license.id)).willReturn(license)
+
+            // When
+            val result = sut.getById(license.id)
+
+            // Then
+            assertThat(result.planId).isEqualTo(defaultPlanId)
+            assertThat(result.period.startDate).isEqualTo(LocalDate.of(2025, 1, 1))
+            assertThat(result.period.endDate).isEqualTo(LocalDate.of(2025, 12, 31))
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 ID로 조회하면 예외가 발생한다")
+        fun `throw exception when license not found`() {
+            // Given
+            val licenseId = LicenseId.generate()
+            given(licenseRepository.loadById(licenseId))
+                .willThrow(LicenseException(LicenseErrorCode.LICENSE_NOT_FOUND))
+
+            // When & Then
+            assertThatThrownBy {
+                sut.getById(licenseId)
+            }.isInstanceOf(LicenseException::class.java)
+                .extracting("errorCode")
+                .isEqualTo(LicenseErrorCode.LICENSE_NOT_FOUND)
+        }
+
+        @Test
+        @DisplayName("삭제된 라이선스를 조회하면 예외가 발생한다")
+        fun `throw exception when trying to get deleted license`() {
+            // Given
+            val licenseId = LicenseId.generate()
+            given(licenseRepository.loadById(licenseId))
+                .willThrow(LicenseException(LicenseErrorCode.LICENSE_NOT_FOUND))
+
+            // When & Then
+            assertThatThrownBy {
+                sut.getById(licenseId)
+            }.isInstanceOf(LicenseException::class.java)
+                .extracting("errorCode")
+                .isEqualTo(LicenseErrorCode.LICENSE_NOT_FOUND)
+        }
+    }
+
+    @Nested
+    @DisplayName("getByOwner")
+    inner class GetByOwner {
+
+        @Test
+        @DisplayName("Owner로 라이선스 목록을 조회할 수 있다")
+        fun `get licenses by owner successfully`() {
+            // Given
+            val license1 = License.create(
+                planId = defaultPlanId,
+                owner = defaultOwner,
+                period = defaultPeriod
+            )
+            val license2 = License.create(
+                planId = defaultPlanId,
+                owner = defaultOwner,
+                period = Period.of(
+                    LocalDate.of(2026, 1, 1),
+                    LocalDate.of(2026, 12, 31)
+                )
+            )
+            given(licenseRepository.loadByOwner(defaultOwner))
+                .willReturn(listOf(license1, license2))
+
+            // When
+            val result = sut.getByOwner(defaultOwner)
+
+            // Then
+            assertThat(result).hasSize(2)
+            assertThat(result.map { it.id }).containsExactlyInAnyOrder(license1.id, license2.id)
+            assertThat(result.all { it.owner == defaultOwner }).isTrue()
+            assertThat(result.all { it.deleted.not() }).isTrue()
+        }
+
+        @Test
+        @DisplayName("Organization Owner로 라이선스를 조회할 수 있다")
+        fun `get licenses by organization owner successfully`() {
+            // Given
+            val orgOwner = Owner.organization("org-456")
+            val license = License.create(
+                planId = defaultPlanId,
+                owner = orgOwner,
+                period = defaultPeriod
+            )
+            given(licenseRepository.loadByOwner(orgOwner))
+                .willReturn(listOf(license))
+
+            // When
+            val result = sut.getByOwner(orgOwner)
+
+            // Then
+            assertThat(result).hasSize(1)
+            assertThat(result[0].owner.type).isEqualTo(Owner.Type.ORGANIZATION)
+            assertThat(result[0].owner.id).isEqualTo("org-456")
+        }
+
+        @Test
+        @DisplayName("Owner에 해당하는 라이선스가 없으면 빈 목록을 반환한다")
+        fun `return empty list when no licenses exist for owner`() {
+            // Given
+            val owner = Owner.user("user-999")
+            given(licenseRepository.loadByOwner(owner)).willReturn(emptyList())
+
+            // When
+            val result = sut.getByOwner(owner)
+
+            // Then
+            assertThat(result).isEmpty()
+        }
+
+        @Test
+        @DisplayName("조회된 라이선스는 모두 ACTIVE 상태이다")
+        fun `all returned licenses are active`() {
+            // Given
+            val license1 = License.create(
+                planId = defaultPlanId,
+                owner = defaultOwner,
+                period = defaultPeriod
+            )
+            val license2 = License.create(
+                planId = PlanId.generate(),
+                owner = defaultOwner,
+                period = defaultPeriod
+            )
+            given(licenseRepository.loadByOwner(defaultOwner))
+                .willReturn(listOf(license1, license2))
+
+            // When
+            val result = sut.getByOwner(defaultOwner)
+
+            // Then
+            assertThat(result.all { it.status == LicenseStatus.ACTIVE }).isTrue()
+            assertThat(result.all { it.deleted.not() }).isTrue()
+        }
+
+        @Test
+        @DisplayName("여러 Owner 타입의 라이선스를 각각 조회할 수 있다")
+        fun `can get licenses for different owner types`() {
+            // Given
+            val userOwner = Owner.user("user-100")
+            val orgOwner = Owner.organization("org-200")
+
+            val userLicense = License.create(
+                planId = defaultPlanId,
+                owner = userOwner,
+                period = defaultPeriod
+            )
+            val orgLicense = License.create(
+                planId = defaultPlanId,
+                owner = orgOwner,
+                period = defaultPeriod
+            )
+
+            given(licenseRepository.loadByOwner(userOwner)).willReturn(listOf(userLicense))
+            given(licenseRepository.loadByOwner(orgOwner)).willReturn(listOf(orgLicense))
+
+            // When
+            val userResult = sut.getByOwner(userOwner)
+            val orgResult = sut.getByOwner(orgOwner)
+
+            // Then
+            assertThat(userResult).hasSize(1)
+            assertThat(userResult[0].owner.type).isEqualTo(Owner.Type.USER)
+            assertThat(orgResult).hasSize(1)
+            assertThat(orgResult[0].owner.type).isEqualTo(Owner.Type.ORGANIZATION)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- License.validateUsable() 메서드 추가로 도메인 캡슐화 강화
- LicenseCommandService에서 License 생성 시 Plan 존재 여부 사전 검증
- validateUsable() 5가지 시나리오 단위테스트 추가
- Plan 미존재 시 예외 처리 테스트 추가

## Changes

| 파일 | 변경 내용 |
|------|---------|
| `License.kt` | validateUsable() 메서드 추가 |
| `LicenseCommandService.kt` | PlanQueryService 의존성 추가, create()에서 Plan 검증 |
| `LicenseTest.kt` | validateUsable() 5개 테스트 케이스 추가 |
| `LicenseCommandServiceTest.kt` | Plan 검증 테스트, mock planQueryService 추가 |

## Test plan

- [x] `gradlew test` 전체 통과
- [x] `gradlew build` 성공

Closes #30